### PR TITLE
sign and publish to maven central

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ ci_test: clean
 #    </server>
 #
 publish: build
+	@test -n "$$BINTRAY_USER" || (echo "BINTRAY_USER must be defined to publish" && false)
+	@test -n "$$BINTRAY_API_KEY" || (echo "BINTRAY_API_KEY must be defined to publish" && false)
+	@test -n "$$MAVEN_CENTRAL_USER_TOKEN" || (echo "MAVEN_CENTRAL_USER_TOKEN must be defined to publish" && false)
+	@test -n "$$MAVEN_CENTRAL_TOKEN_PASSWORD" || (echo "MAVEN_CENTRAL_TOKEN_PASSWORD must be defined to publish" && false)
+	@test -n "$$BINTRAY_GPG_PASSPHRASE" || (echo "$$BINTRAY_GPG_PASSPHRASE must be defined to publish" && false)
+
 	@git diff-index --quiet HEAD || (echo "git has uncommitted changes. Refusing to publish." && false)
-	./inc-version.sh
-	mvn deploy
+	#./inc-version.sh
+	#mvn deploy
+
+	curl -H "X-GPG-PASSPHRASE:$$$$BINTRAY_GPG_PASSPHRASE" -u $$BINTRAY_USER:$$BINTRAY_API_KEY -X POST https://api.bintray.com/gpg/lightstep/maven/java-common/versions/0.12.7

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,4 @@ publish: build
 	@test -n "$$BINTRAY_GPG_PASSPHRASE" || (echo "$$BINTRAY_GPG_PASSPHRASE must be defined to publish" && false)
 
 	@git diff-index --quiet HEAD || (echo "git has uncommitted changes. Refusing to publish." && false)
-	#./inc-version.sh
-	#mvn deploy
-
-	curl -H "X-GPG-PASSPHRASE:$$$$BINTRAY_GPG_PASSPHRASE" -u $$BINTRAY_USER:$$BINTRAY_API_KEY -X POST https://api.bintray.com/gpg/lightstep/maven/java-common/versions/0.12.7
+	./inc-version.sh

--- a/inc-version.sh
+++ b/inc-version.sh
@@ -27,3 +27,12 @@ git push
 git push --tags
 
 echo "Updated from $CURRENT_VERSION to $NEW_VERSION"
+
+# Build and deploy to Bintray
+mvn deploy
+
+# Sign the jar and other files in Bintray
+curl -H "X-GPG-PASSPHRASE:$BINTRAY_GPG_PASSPHRASE" -u $BINTRAY_USER:$BINTRAY_API_KEY -X POST https://api.bintray.com/gpg/lightstep/maven/java-common/versions/$NEW_VERSION
+
+# Sync the repository with Maven Central
+curl -H "Content-Type: application/json" -u $BINTRAY_USER:$BINTRAY_API_KEY -X POST -d '{"username":"'$MAVEN_CENTRAL_USER_TOKEN'","password":"'$MAVEN_CENTRAL_TOKEN_PASSWORD'","close":"1"}' https://api.bintray.com/maven_central_sync/lightstep/maven/java-common/versions/$NEW_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>java-common</artifactId>
     <version>0.12.7</version>
     <packaging>jar</packaging>
+    <name>java-common</name>
     <description>The LightStep OpenTracing Tracer implementation for Java</description>
     <url>https://github.com/lightstep/lightstep-tracer-java-common</url>
 


### PR DESCRIPTION
- Added name to pom.xml, otherwise not valid for maven central
- Added sign and sync to bash script, requires same env variables that were previously required with gradle