### PR TITLE
Fix IDE warnings

### DIFF
--- a/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -1,8 +1,8 @@
 package com.lightstep.tracer.shared;
 
-import com.google.protobuf.Timestamp;
 import com.lightstep.tracer.grpc.InternalMetrics;
 import com.lightstep.tracer.grpc.MetricsSample;
+
 import java.util.ArrayList;
 
 /**
@@ -16,24 +16,9 @@ class ClientMetrics {
      */
     private static final int NUMBER_OF_COUNTS = 1;
     long spansDropped;
-    final Timestamp startTime;
 
-
-    ClientMetrics(Timestamp startTime) {
+    ClientMetrics() {
         spansDropped = 0;
-        this.startTime = startTime;
-    }
-
-    ClientMetrics(ClientMetrics that) {
-        spansDropped = that.spansDropped;
-        startTime = that.startTime;
-    }
-
-    void merge(ClientMetrics that) {
-        if (that == null) {
-            return;
-        }
-        spansDropped += that.spansDropped;
     }
 
     InternalMetrics toGrpc() {

--- a/src/main/java/com/lightstep/tracer/shared/ClockState.java
+++ b/src/main/java/com/lightstep/tracer/shared/ClockState.java
@@ -6,7 +6,7 @@ import static java.lang.Long.MAX_VALUE;
 
 class ClockState {
 
-    public static class NoopClockState extends ClockState {
+    static class NoopClockState extends ClockState {
         void addSample(long o, long r, long t, long d) {}
         long offsetMicros() { return 0; }
         boolean isReady() { return true; }

--- a/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -39,6 +39,7 @@ public final class Options {
     /**
      * Default maximum number of Spans buffered locally (a protective mechanism)
      */
+    @SuppressWarnings("WeakerAccess")
     public static final int DEFAULT_MAX_BUFFERED_SPANS = 1000;
 
     /**
@@ -273,6 +274,7 @@ public final class Options {
          * only occur on explicit calls to Flush(); If not set, will default to
          * {@code DEFAULT_REPORTING_INTERVAL_MILLIS}.
          */
+        @SuppressWarnings("SameParameterValue")
         public OptionsBuilder withDisableReportingLoop(boolean disable) {
             this.disableReportingLoop = disable;
             return this;
@@ -287,7 +289,8 @@ public final class Options {
             return this;
         }
 
-	public OptionsBuilder withClockSkewCorrection(boolean clockCorrection) {
+	@SuppressWarnings("SameParameterValue")
+    public OptionsBuilder withClockSkewCorrection(boolean clockCorrection) {
 	    this.useClockCorrection = clockCorrection;
 	    return this;
 	}
@@ -379,6 +382,7 @@ public final class Options {
      *              object is current set to the default value for maxReportingIntervalMillis.
      * @throws IllegalArgumentException If this Options object has an malformed collector url.
      */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public Options setDefaultReportingIntervalMillis(int value) {
         if (maxReportingIntervalMillis != DEFAULT_REPORTING_INTERVAL_MILLIS) {
             return this;
@@ -397,6 +401,7 @@ public final class Options {
      * Provided so implementations of AbstractTracer can turn off resetClient by default.
      * For example, Android tracer may not want resetClient.
      */
+    @SuppressWarnings("unused")
     public Options disableResetClient() {
         try {
             return new OptionsBuilder(this).withResetClient(false).build();

--- a/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
+++ b/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
@@ -10,10 +10,12 @@ public class SimpleFuture<T> {
     private boolean resolved;
     private T value;
 
+    @SuppressWarnings("WeakerAccess")
     public SimpleFuture() {
         resolved = false;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public SimpleFuture(T value) {
         this.value = value;
         resolved = true;
@@ -36,7 +38,7 @@ public class SimpleFuture<T> {
         return value;
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public T getWithTimeout(long millis) throws InterruptedException {
         if (!resolved) {
             synchronized (this) {

--- a/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -104,6 +104,7 @@ public class Span implements io.opentracing.Span {
         return this;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public void close() {
         finish();
     }
@@ -172,6 +173,7 @@ public class Span implements io.opentracing.Span {
         return log(timestampMicroseconds, fields);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public String generateTraceURL() {
         return tracer.generateTraceURL(context.getSpanId());
     }
@@ -197,7 +199,7 @@ public class Span implements io.opentracing.Span {
      * Adapted from https://android.googlesource.com/platform/dalvik/libcore/json/src/main/java/org/json/JSONStringer.java
      */
     static String stringToJSONValue(String value) {
-        StringBuffer out = new StringBuffer(value.length() + 2);
+        StringBuilder out = new StringBuilder(value.length() + 2);
         out.append("\"");
         for (int i = 0, length = value.length(); i < length; i++) {
             char c = value.charAt(i);
@@ -251,6 +253,7 @@ public class Span implements io.opentracing.Span {
     /**
      * For unit testing in JRE test.
      */
+    @SuppressWarnings("WeakerAccess")
     public Builder getGrpcSpan() {
         return grpcSpan;
     }

--- a/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
+++ b/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
@@ -1,16 +1,15 @@
 package com.lightstep.tracer.shared;
 
 import com.lightstep.tracer.grpc.KeyValue;
-
 import com.lightstep.tracer.grpc.Reference;
 import com.lightstep.tracer.grpc.Reference.Relationship;
 import io.opentracing.ActiveSpan;
 import io.opentracing.BaseSpan;
+import io.opentracing.Tracer;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import io.opentracing.Tracer;
 
 import static io.opentracing.References.CHILD_OF;
 import static io.opentracing.References.FOLLOWS_FROM;
@@ -112,12 +111,14 @@ public class SpanBuilder implements Tracer.SpanBuilder {
      * Sets the traceId and the spanId for the span being created. If the span has a parent, the
      * traceId of the parent will override this traceId value.
      */
+    @SuppressWarnings({"WeakerAccess", "UnusedReturnValue", "SameParameterValue"})
     public Tracer.SpanBuilder withTraceIdAndSpanId(long traceId, long spanId) {
         this.traceId = traceId;
         this.spanId = spanId;
         return this;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public Iterable<Map.Entry<String, String>> baggageItems() {
         if (parent == null) {
             return Collections.emptySet();

--- a/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -1,8 +1,9 @@
 package com.lightstep.tracer.shared;
 
+import com.lightstep.tracer.grpc.SpanContext.Builder;
+
 import java.util.HashMap;
 import java.util.Map;
-import com.lightstep.tracer.grpc.SpanContext.Builder;
 
 public class SpanContext implements io.opentracing.SpanContext {
     private final Builder ctxBuilder = com.lightstep.tracer.grpc.SpanContext.newBuilder();
@@ -36,10 +37,12 @@ public class SpanContext implements io.opentracing.SpanContext {
         this(traceId, null);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public long getSpanId() {
         return ctxBuilder.getSpanId();
     }
 
+    @SuppressWarnings("WeakerAccess")
     public long getTraceId() {
         return ctxBuilder.getTraceId();
     }
@@ -65,6 +68,7 @@ public class SpanContext implements io.opentracing.SpanContext {
         return ctxBuilder.getBaggageMap().entrySet();
     }
 
+    @SuppressWarnings("WeakerAccess")
     public Builder getInnerSpanCtx() {
         return ctxBuilder;
     }

--- a/src/main/java/com/lightstep/tracer/shared/Status.java
+++ b/src/main/java/com/lightstep/tracer/shared/Status.java
@@ -21,14 +21,17 @@ public class Status {
         }
     }
 
+    @SuppressWarnings("unused")
     public long getSpansDropped() {
         return spansDropped;
     }
 
+    @SuppressWarnings("unused")
     public boolean hasTag(String key) {
         return tags.containsKey(key);
     }
 
+    @SuppressWarnings("unused")
     public String getTag(String key) {
         return tags.get(key);
     }

--- a/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
+++ b/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
@@ -2,7 +2,6 @@ package com.lightstep.tracer.shared;
 
 import com.lightstep.tracer.grpc.KeyValue;
 import com.lightstep.tracer.grpc.Span.Builder;
-import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/lightstep/tracer/shared/SpanTest.java
+++ b/src/test/java/com/lightstep/tracer/shared/SpanTest.java
@@ -3,7 +3,6 @@ package com.lightstep.tracer.shared;
 import com.lightstep.tracer.grpc.KeyValue;
 import com.lightstep.tracer.grpc.Log;
 import com.lightstep.tracer.grpc.Span.Builder;
-import java.util.logging.LogRecord;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/lightstep/tracer/shared/StubTracer.java
+++ b/src/test/java/com/lightstep/tracer/shared/StubTracer.java
@@ -32,10 +32,6 @@ class StubTracer extends AbstractTracer {
         return consoleLogCalls.isEmpty();
     }
 
-    void resetConsoleLogCalls() {
-        consoleLogCalls.clear();
-    }
-
     int getNumberOfConsoleLogCalls() {
         if (consoleLogCallsIsEmpty()) {
             return 0;


### PR DESCRIPTION
Mostly about unused methods or parameters. Most are used in the (now)
other repos lightstep-tracer-java and lightstep-tracer-android, but
in a few cases the things were not really used and I removed them
or downgraded their access. All other items are merely SuppressWarnings
for IntelliJ users.