### PR TITLE
Do not lock CollectorClient to manage ClientMetrics

### DIFF
--- a/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -621,7 +621,7 @@ public abstract class AbstractTracer implements Tracer {
         synchronized (mutex) {
             long spansDropped = 0;
             if (client != null) {
-                spansDropped = client.getClientMetrics().spansDropped;
+                spansDropped = client.getClientMetrics().getSpansDropped();
             }
             return new Status(reporter.getTagsList(), spansDropped);
         }

--- a/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -33,4 +33,8 @@ class ClientMetrics {
                 .setIntValue(val).build());
         return InternalMetrics.newBuilder().addAllCounts(counts).build();
     }
+
+    long getSpansDropped() {
+        return spansDropped.get();
+    }
 }

--- a/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -16,7 +16,7 @@ class ClientMetrics {
      * tracked.
      */
     private static final int NUMBER_OF_COUNTS = 1;
-    private AtomicLong spansDropped;
+    private final AtomicLong spansDropped;
 
     ClientMetrics() {
         spansDropped = new AtomicLong(0);

--- a/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -4,6 +4,7 @@ import com.lightstep.tracer.grpc.InternalMetrics;
 import com.lightstep.tracer.grpc.MetricsSample;
 
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Tracks client metrics for internal purposes.
@@ -15,17 +16,21 @@ class ClientMetrics {
      * tracked.
      */
     private static final int NUMBER_OF_COUNTS = 1;
-    long spansDropped;
+    private AtomicLong spansDropped;
 
     ClientMetrics() {
-        spansDropped = 0;
+        spansDropped = new AtomicLong(0);
     }
 
-    InternalMetrics toGrpc() {
+    void dropSpans(int size) {
+        spansDropped.addAndGet(size);
+    }
+
+    InternalMetrics toGrpcAndReset() {
+        long val = spansDropped.getAndSet(0);
         ArrayList<MetricsSample> counts = new ArrayList<>(NUMBER_OF_COUNTS);
         counts.add(MetricsSample.newBuilder().setName("spans.dropped")
-            .setIntValue(spansDropped).build());
+                .setIntValue(val).build());
         return InternalMetrics.newBuilder().addAllCounts(counts).build();
-
     }
 }


### PR DESCRIPTION
Use an AtomicLong instead of locking the entire CollectorClient when updating droppedSpans in ClientMetrics.

LS-1230