### PR TITLE
Send report when span buffer reaches 50% capacity

### DIFF
--- a/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -213,7 +213,7 @@ public abstract class AbstractTracer implements Tracer {
                     client.reconnect();
                     nextResetMillis = System.currentTimeMillis() + DEFAULT_CLIENT_RESET_INTERVAL_MILLIS;
                 }
-                if (nowMillis >= nextReportMillis) {
+                if (spans.size() >= (maxBufferedSpans/2) || nowMillis >= nextReportMillis) {
                     SimpleFuture<Boolean> result = flushInternal(false);
                     boolean reportSucceeded = false;
                     try {


### PR DESCRIPTION
This is what the go client does and is better than what the
java client does now which is to drops spans until the time
interval is reached.

LS-1147