### PR TITLE
Only call ManagedChannelBuilder.usePlaintext for http

### DIFF
--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
@@ -3,8 +3,6 @@ package com.lightstep.tracer.shared;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
 
-import java.net.URL;
-
 // public for reflective instantiation.
 public class GrpcCollectorClientProvider extends CollectorClientProvider {
     private static GrpcCollectorClientProvider INSTANCE = new GrpcCollectorClientProvider();
@@ -29,12 +27,16 @@ public class GrpcCollectorClientProvider extends CollectorClientProvider {
             Options options
     ) {
         try {
+            ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
+                    options.collectorUrl.getHost(),
+                    options.collectorUrl.getPort()
+            );
+            if (options.collectorUrl.getProtocol().equals("http")) {
+                builder.usePlaintext(true);
+            }
             return new GrpcCollectorClient(
                     tracer,
-                    ManagedChannelBuilder.forAddress(
-                            options.collectorUrl.getHost(),
-                            options.collectorUrl.getPort()
-                    ).usePlaintext(options.collectorUrl.getProtocol().equals("http")),
+                    builder,
                     options.deadlineMillis
             );
         } catch (ManagedChannelProvider.ProviderNotFoundException e) {


### PR DESCRIPTION
If you call ManagedChannelBuilder.usePlaintext(false) it tells
the NettyChannelBuilder to use PLAINTEXT_UPGRADE instead of
TLS for negotiation.