### PR TITLE
do not add parent_span_guid, we have references now

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
@@ -155,6 +155,7 @@ public class SpanBuilder implements Tracer.SpanBuilder {
 
         if(parent == null && !ignoringActiveSpan) {
             parent = activeSpanContext();
+            this.asChildOf(parent);
         }
 
         if (parent != null) {

--- a/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
@@ -14,11 +14,6 @@ import static io.opentracing.References.CHILD_OF;
 import static io.opentracing.References.FOLLOWS_FROM;
 
 public class SpanBuilder implements Tracer.SpanBuilder {
-    /**
-     * The tag key used to record the relationship between child and parent
-     * spans.
-     */
-    static final String PARENT_SPAN_GUID_KEY = "parent_span_guid";
 
     private final String operationName;
     private final Map<String, String> stringTags;
@@ -164,8 +159,6 @@ public class SpanBuilder implements Tracer.SpanBuilder {
 
         if (parent != null) {
             traceId = parent.getTraceId();
-            grpcSpan.addTags(KeyValue.newBuilder().setKey(PARENT_SPAN_GUID_KEY)
-                .setIntValue(parent.getSpanId()));
         }
         SpanContext newSpanContext;
         if (traceId != null && spanId != null) {

--- a/common/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.lightstep.tracer.shared.SpanBuilder.PARENT_SPAN_GUID_KEY;
 import static io.opentracing.References.FOLLOWS_FROM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -192,11 +191,6 @@ public class SpanBuilderTest {
         // verify that parent's trace id is set on context in returned span
         SpanContext spanContext = lsSpan.context();
         assertEquals(TRACE_ID, spanContext.getTraceId());
-
-        // verify that record has span id set
-        Builder spanRecord = lsSpan.getGrpcSpan();
-        List<KeyValue> attributes = spanRecord.getTagsList();
-        assertTrue(attributes.contains(KeyValue.newBuilder().setKey(PARENT_SPAN_GUID_KEY).setIntValue(SPAN_ID).build()));
 
         verifyResultingSpan(lsSpan);
         assertEquals(TRACE_ID, context.getTraceId());


### PR DESCRIPTION
In the old thrift world, we used tag `parent_span_guid` to identity parent-child span relationships. In the proto world, there is an explicit `reference` field used for this. The old thrift code was left in place alongside the reference code, which caused non-deterministic behavior in the collector. 

This removes the tag `parent_span_guid` as we use proto only now.