### PR TITLE
update proto definition to latest version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <io.opentracing.version>0.31.0</io.opentracing.version>
         <com.google.protobuf.version>3.5.1</com.google.protobuf.version>
+        <com.google.api.version>0.0.3</com.google.api.version>
     </properties>
 
     <build>
@@ -67,6 +68,12 @@
             <artifactId>protobuf-java</artifactId>
             <version>${com.google.protobuf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>googleapis-common-protos</artifactId>
+            <version>${com.google.api.version}</version>
+        </dependency>
+
 
         <!-- Test Dependencies -->
         <dependency>

--- a/common/src/main/java/com/lightstep/tracer/grpc/Auth.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Auth.java
@@ -10,6 +10,7 @@ public  final class Auth extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Auth)
     AuthOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Auth.newBuilder() to construct.
   private Auth(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -21,14 +22,19 @@ public  final class Auth extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Auth(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +44,8 @@ public  final class Auth extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -57,6 +64,7 @@ public  final class Auth extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -75,7 +83,7 @@ public  final class Auth extends
   public static final int ACCESS_TOKEN_FIELD_NUMBER = 1;
   private volatile java.lang.Object accessToken_;
   /**
-   * <code>optional string access_token = 1;</code>
+   * <code>string access_token = 1;</code>
    */
   public java.lang.String getAccessToken() {
     java.lang.Object ref = accessToken_;
@@ -90,7 +98,7 @@ public  final class Auth extends
     }
   }
   /**
-   * <code>optional string access_token = 1;</code>
+   * <code>string access_token = 1;</code>
    */
   public com.google.protobuf.ByteString
       getAccessTokenBytes() {
@@ -121,6 +129,7 @@ public  final class Auth extends
     if (!getAccessTokenBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, accessToken_);
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -131,11 +140,11 @@ public  final class Auth extends
     if (!getAccessTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, accessToken_);
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -149,6 +158,7 @@ public  final class Auth extends
     boolean result = true;
     result = result && getAccessToken()
         .equals(other.getAccessToken());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -158,7 +168,7 @@ public  final class Auth extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + ACCESS_TOKEN_FIELD_NUMBER;
     hash = (53 * hash) + getAccessToken().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
@@ -166,6 +176,17 @@ public  final class Auth extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Auth parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Auth parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Auth parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -313,7 +334,7 @@ public  final class Auth extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -326,12 +347,12 @@ public  final class Auth extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -349,6 +370,7 @@ public  final class Auth extends
         accessToken_ = other.accessToken_;
         onChanged();
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -377,7 +399,7 @@ public  final class Auth extends
 
     private java.lang.Object accessToken_ = "";
     /**
-     * <code>optional string access_token = 1;</code>
+     * <code>string access_token = 1;</code>
      */
     public java.lang.String getAccessToken() {
       java.lang.Object ref = accessToken_;
@@ -392,7 +414,7 @@ public  final class Auth extends
       }
     }
     /**
-     * <code>optional string access_token = 1;</code>
+     * <code>string access_token = 1;</code>
      */
     public com.google.protobuf.ByteString
         getAccessTokenBytes() {
@@ -408,7 +430,7 @@ public  final class Auth extends
       }
     }
     /**
-     * <code>optional string access_token = 1;</code>
+     * <code>string access_token = 1;</code>
      */
     public Builder setAccessToken(
         java.lang.String value) {
@@ -421,7 +443,7 @@ public  final class Auth extends
       return this;
     }
     /**
-     * <code>optional string access_token = 1;</code>
+     * <code>string access_token = 1;</code>
      */
     public Builder clearAccessToken() {
       
@@ -430,7 +452,7 @@ public  final class Auth extends
       return this;
     }
     /**
-     * <code>optional string access_token = 1;</code>
+     * <code>string access_token = 1;</code>
      */
     public Builder setAccessTokenBytes(
         com.google.protobuf.ByteString value) {
@@ -445,12 +467,12 @@ public  final class Auth extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -473,7 +495,7 @@ public  final class Auth extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Auth(input, extensionRegistry);
+      return new Auth(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/AuthOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/AuthOrBuilder.java
@@ -8,11 +8,11 @@ public interface AuthOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional string access_token = 1;</code>
+   * <code>string access_token = 1;</code>
    */
   java.lang.String getAccessToken();
   /**
-   * <code>optional string access_token = 1;</code>
+   * <code>string access_token = 1;</code>
    */
   com.google.protobuf.ByteString
       getAccessTokenBytes();

--- a/common/src/main/java/com/lightstep/tracer/grpc/Collector.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Collector.java
@@ -89,57 +89,59 @@ public final class Collector {
   static {
     java.lang.String[] descriptorData = {
       "\n\017collector.proto\022\023lightstep.collector\032\037" +
-      "google/protobuf/timestamp.proto\"\240\001\n\013Span" +
-      "Context\022\020\n\010trace_id\030\001 \001(\004\022\017\n\007span_id\030\002 \001" +
-      "(\004\022>\n\007baggage\030\003 \003(\0132-.lightstep.collecto" +
-      "r.SpanContext.BaggageEntry\032.\n\014BaggageEnt" +
-      "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\221\001\n\010K" +
-      "eyValue\022\013\n\003key\030\001 \001(\t\022\026\n\014string_value\030\002 \001" +
-      "(\tH\000\022\023\n\tint_value\030\003 \001(\003H\000\022\026\n\014double_valu" +
-      "e\030\004 \001(\001H\000\022\024\n\nbool_value\030\005 \001(\010H\000\022\024\n\njson_" +
-      "value\030\006 \001(\tH\000B\007\n\005value\"f\n\003Log\022-\n\ttimesta",
-      "mp\030\001 \001(\0132\032.google.protobuf.Timestamp\0220\n\t" +
-      "keyvalues\030\002 \003(\0132\035.lightstep.collector.Ke" +
-      "yValue\"\266\001\n\tReference\022A\n\014relationship\030\001 \001" +
-      "(\0162+.lightstep.collector.Reference.Relat" +
-      "ionship\0226\n\014span_context\030\002 \001(\0132 .lightste" +
-      "p.collector.SpanContext\".\n\014Relationship\022" +
-      "\014\n\010CHILD_OF\020\000\022\020\n\014FOLLOWS_FROM\020\001\"\255\002\n\004Span" +
-      "\0226\n\014span_context\030\001 \001(\0132 .lightstep.colle" +
-      "ctor.SpanContext\022\026\n\016operation_name\030\002 \001(\t" +
-      "\0222\n\nreferences\030\003 \003(\0132\036.lightstep.collect",
-      "or.Reference\0223\n\017start_timestamp\030\004 \001(\0132\032." +
-      "google.protobuf.Timestamp\022\027\n\017duration_mi" +
-      "cros\030\005 \001(\004\022+\n\004tags\030\006 \003(\0132\035.lightstep.col" +
-      "lector.KeyValue\022&\n\004logs\030\007 \003(\0132\030.lightste" +
-      "p.collector.Log\"L\n\010Reporter\022\023\n\013reporter_" +
-      "id\030\001 \001(\004\022+\n\004tags\030\004 \003(\0132\035.lightstep.colle" +
-      "ctor.KeyValue\"S\n\rMetricsSample\022\014\n\004name\030\001" +
-      " \001(\t\022\023\n\tint_value\030\002 \001(\003H\000\022\026\n\014double_valu" +
-      "e\030\003 \001(\001H\000B\007\n\005value\"\357\001\n\017InternalMetrics\0223" +
-      "\n\017start_timestamp\030\001 \001(\0132\032.google.protobu",
-      "f.Timestamp\022\027\n\017duration_micros\030\002 \001(\004\022&\n\004" +
-      "logs\030\003 \003(\0132\030.lightstep.collector.Log\0222\n\006" +
-      "counts\030\004 \003(\0132\".lightstep.collector.Metri" +
-      "csSample\0222\n\006gauges\030\005 \003(\0132\".lightstep.col" +
-      "lector.MetricsSample\"\034\n\004Auth\022\024\n\014access_t" +
-      "oken\030\001 \001(\t\"\364\001\n\rReportRequest\022/\n\010reporter" +
-      "\030\001 \001(\0132\035.lightstep.collector.Reporter\022\'\n" +
-      "\004auth\030\002 \001(\0132\031.lightstep.collector.Auth\022(" +
-      "\n\005spans\030\003 \003(\0132\031.lightstep.collector.Span" +
-      "\022\037\n\027timestamp_offset_micros\030\005 \001(\r\022>\n\020int",
-      "ernal_metrics\030\006 \001(\0132$.lightstep.collecto" +
-      "r.InternalMetrics\"\032\n\007Command\022\017\n\007disable\030" +
-      "\001 \001(\010\"\277\001\n\016ReportResponse\022.\n\010commands\030\001 \003" +
-      "(\0132\034.lightstep.collector.Command\0225\n\021rece" +
-      "ive_timestamp\030\002 \001(\0132\032.google.protobuf.Ti" +
-      "mestamp\0226\n\022transmit_timestamp\030\003 \001(\0132\032.go" +
-      "ogle.protobuf.Timestamp\022\016\n\006errors\030\004 \003(\t2" +
-      "e\n\020CollectorService\022Q\n\006Report\022\".lightste" +
-      "p.collector.ReportRequest\032#.lightstep.co" +
-      "llector.ReportResponseB1\n\031com.lightstep.",
-      "tracer.grpcP\001Z\013collectorpb\242\002\004LSPBb\006proto" +
-      "3"
+      "google/protobuf/timestamp.proto\032\034google/" +
+      "api/annotations.proto\"\240\001\n\013SpanContext\022\020\n" +
+      "\010trace_id\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004\022>\n\007bagg" +
+      "age\030\003 \003(\0132-.lightstep.collector.SpanCont" +
+      "ext.BaggageEntry\032.\n\014BaggageEntry\022\013\n\003key\030" +
+      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\221\001\n\010KeyValue\022\013\n" +
+      "\003key\030\001 \001(\t\022\026\n\014string_value\030\002 \001(\tH\000\022\023\n\tin" +
+      "t_value\030\003 \001(\003H\000\022\026\n\014double_value\030\004 \001(\001H\000\022" +
+      "\024\n\nbool_value\030\005 \001(\010H\000\022\024\n\njson_value\030\006 \001(" +
+      "\tH\000B\007\n\005value\"c\n\003Log\022-\n\ttimestamp\030\001 \001(\0132\032" +
+      ".google.protobuf.Timestamp\022-\n\006fields\030\002 \003" +
+      "(\0132\035.lightstep.collector.KeyValue\"\266\001\n\tRe" +
+      "ference\022A\n\014relationship\030\001 \001(\0162+.lightste" +
+      "p.collector.Reference.Relationship\0226\n\014sp" +
+      "an_context\030\002 \001(\0132 .lightstep.collector.S" +
+      "panContext\".\n\014Relationship\022\014\n\010CHILD_OF\020\000" +
+      "\022\020\n\014FOLLOWS_FROM\020\001\"\255\002\n\004Span\0226\n\014span_cont" +
+      "ext\030\001 \001(\0132 .lightstep.collector.SpanCont" +
+      "ext\022\026\n\016operation_name\030\002 \001(\t\0222\n\nreference" +
+      "s\030\003 \003(\0132\036.lightstep.collector.Reference\022" +
+      "3\n\017start_timestamp\030\004 \001(\0132\032.google.protob" +
+      "uf.Timestamp\022\027\n\017duration_micros\030\005 \001(\004\022+\n" +
+      "\004tags\030\006 \003(\0132\035.lightstep.collector.KeyVal" +
+      "ue\022&\n\004logs\030\007 \003(\0132\030.lightstep.collector.L" +
+      "og\"L\n\010Reporter\022\023\n\013reporter_id\030\001 \001(\004\022+\n\004t" +
+      "ags\030\004 \003(\0132\035.lightstep.collector.KeyValue" +
+      "\"S\n\rMetricsSample\022\014\n\004name\030\001 \001(\t\022\023\n\tint_v" +
+      "alue\030\002 \001(\003H\000\022\026\n\014double_value\030\003 \001(\001H\000B\007\n\005" +
+      "value\"\357\001\n\017InternalMetrics\0223\n\017start_times" +
+      "tamp\030\001 \001(\0132\032.google.protobuf.Timestamp\022\027" +
+      "\n\017duration_micros\030\002 \001(\004\022&\n\004logs\030\003 \003(\0132\030." +
+      "lightstep.collector.Log\0222\n\006counts\030\004 \003(\0132" +
+      "\".lightstep.collector.MetricsSample\0222\n\006g" +
+      "auges\030\005 \003(\0132\".lightstep.collector.Metric" +
+      "sSample\"\034\n\004Auth\022\024\n\014access_token\030\001 \001(\t\"\364\001" +
+      "\n\rReportRequest\022/\n\010reporter\030\001 \001(\0132\035.ligh" +
+      "tstep.collector.Reporter\022\'\n\004auth\030\002 \001(\0132\031" +
+      ".lightstep.collector.Auth\022(\n\005spans\030\003 \003(\013" +
+      "2\031.lightstep.collector.Span\022\037\n\027timestamp" +
+      "_offset_micros\030\005 \001(\003\022>\n\020internal_metrics" +
+      "\030\006 \001(\0132$.lightstep.collector.InternalMet" +
+      "rics\"\032\n\007Command\022\017\n\007disable\030\001 \001(\010\"\340\001\n\016Rep" +
+      "ortResponse\022.\n\010commands\030\001 \003(\0132\034.lightste" +
+      "p.collector.Command\0225\n\021receive_timestamp" +
+      "\030\002 \001(\0132\032.google.protobuf.Timestamp\0226\n\022tr" +
+      "ansmit_timestamp\030\003 \001(\0132\032.google.protobuf" +
+      ".Timestamp\022\016\n\006errors\030\004 \003(\t\022\020\n\010warnings\030\005" +
+      " \003(\t\022\r\n\005infos\030\006 \003(\t2\225\001\n\020CollectorService" +
+      "\022\200\001\n\006Report\022\".lightstep.collector.Report" +
+      "Request\032#.lightstep.collector.ReportResp" +
+      "onse\"-\202\323\344\223\002\'\"\017/api/v2/reports:\001*Z\021\022\017/api" +
+      "/v2/reportsB1\n\031com.lightstep.tracer.grpc" +
+      "P\001Z\013collectorpb\242\002\004LSPBb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -153,6 +155,7 @@ public final class Collector {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.TimestampProto.getDescriptor(),
+          com.google.api.AnnotationsProto.getDescriptor(),
         }, assigner);
     internal_static_lightstep_collector_SpanContext_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -177,7 +180,7 @@ public final class Collector {
     internal_static_lightstep_collector_Log_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_lightstep_collector_Log_descriptor,
-        new java.lang.String[] { "Timestamp", "Keyvalues", });
+        new java.lang.String[] { "Timestamp", "Fields", });
     internal_static_lightstep_collector_Reference_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_lightstep_collector_Reference_fieldAccessorTable = new
@@ -231,8 +234,14 @@ public final class Collector {
     internal_static_lightstep_collector_ReportResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_lightstep_collector_ReportResponse_descriptor,
-        new java.lang.String[] { "Commands", "ReceiveTimestamp", "TransmitTimestamp", "Errors", });
+        new java.lang.String[] { "Commands", "ReceiveTimestamp", "TransmitTimestamp", "Errors", "Warnings", "Infos", });
+    com.google.protobuf.ExtensionRegistry registry =
+        com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(com.google.api.AnnotationsProto.http);
+    com.google.protobuf.Descriptors.FileDescriptor
+        .internalUpdateFileDescriptor(descriptor, registry);
     com.google.protobuf.TimestampProto.getDescriptor();
+    com.google.api.AnnotationsProto.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/common/src/main/java/com/lightstep/tracer/grpc/Command.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Command.java
@@ -10,6 +10,7 @@ public  final class Command extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Command)
     CommandOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Command.newBuilder() to construct.
   private Command(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -21,14 +22,19 @@ public  final class Command extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Command(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +44,8 @@ public  final class Command extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -56,6 +63,7 @@ public  final class Command extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -74,7 +82,7 @@ public  final class Command extends
   public static final int DISABLE_FIELD_NUMBER = 1;
   private boolean disable_;
   /**
-   * <code>optional bool disable = 1;</code>
+   * <code>bool disable = 1;</code>
    */
   public boolean getDisable() {
     return disable_;
@@ -95,6 +103,7 @@ public  final class Command extends
     if (disable_ != false) {
       output.writeBool(1, disable_);
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -106,11 +115,11 @@ public  final class Command extends
       size += com.google.protobuf.CodedOutputStream
         .computeBoolSize(1, disable_);
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -124,6 +133,7 @@ public  final class Command extends
     boolean result = true;
     result = result && (getDisable()
         == other.getDisable());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -133,7 +143,7 @@ public  final class Command extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + DISABLE_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
         getDisable());
@@ -142,6 +152,17 @@ public  final class Command extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Command parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Command parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Command parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -289,7 +310,7 @@ public  final class Command extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -302,12 +323,12 @@ public  final class Command extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -324,6 +345,7 @@ public  final class Command extends
       if (other.getDisable() != false) {
         setDisable(other.getDisable());
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -352,13 +374,13 @@ public  final class Command extends
 
     private boolean disable_ ;
     /**
-     * <code>optional bool disable = 1;</code>
+     * <code>bool disable = 1;</code>
      */
     public boolean getDisable() {
       return disable_;
     }
     /**
-     * <code>optional bool disable = 1;</code>
+     * <code>bool disable = 1;</code>
      */
     public Builder setDisable(boolean value) {
       
@@ -367,7 +389,7 @@ public  final class Command extends
       return this;
     }
     /**
-     * <code>optional bool disable = 1;</code>
+     * <code>bool disable = 1;</code>
      */
     public Builder clearDisable() {
       
@@ -377,12 +399,12 @@ public  final class Command extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -405,7 +427,7 @@ public  final class Command extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Command(input, extensionRegistry);
+      return new Command(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/CommandOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/CommandOrBuilder.java
@@ -8,7 +8,7 @@ public interface CommandOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional bool disable = 1;</code>
+   * <code>bool disable = 1;</code>
    */
   boolean getDisable();
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/InternalMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/InternalMetrics.java
@@ -10,6 +10,7 @@ public  final class InternalMetrics extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.InternalMetrics)
     InternalMetricsOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use InternalMetrics.newBuilder() to construct.
   private InternalMetrics(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -24,14 +25,19 @@ public  final class InternalMetrics extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private InternalMetrics(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -41,7 +47,8 @@ public  final class InternalMetrics extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -108,6 +115,7 @@ public  final class InternalMetrics extends
       if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
         gauges_ = java.util.Collections.unmodifiableList(gauges_);
       }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -127,19 +135,19 @@ public  final class InternalMetrics extends
   public static final int START_TIMESTAMP_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp startTimestamp_;
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   public boolean hasStartTimestamp() {
     return startTimestamp_ != null;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   public com.google.protobuf.Timestamp getStartTimestamp() {
     return startTimestamp_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : startTimestamp_;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   public com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder() {
     return getStartTimestamp();
@@ -148,7 +156,7 @@ public  final class InternalMetrics extends
   public static final int DURATION_MICROS_FIELD_NUMBER = 2;
   private long durationMicros_;
   /**
-   * <code>optional uint64 duration_micros = 2;</code>
+   * <code>uint64 duration_micros = 2;</code>
    */
   public long getDurationMicros() {
     return durationMicros_;
@@ -286,6 +294,7 @@ public  final class InternalMetrics extends
     for (int i = 0; i < gauges_.size(); i++) {
       output.writeMessage(5, gauges_.get(i));
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -313,11 +322,11 @@ public  final class InternalMetrics extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(5, gauges_.get(i));
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -342,6 +351,7 @@ public  final class InternalMetrics extends
         .equals(other.getCountsList());
     result = result && getGaugesList()
         .equals(other.getGaugesList());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -351,7 +361,7 @@ public  final class InternalMetrics extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     if (hasStartTimestamp()) {
       hash = (37 * hash) + START_TIMESTAMP_FIELD_NUMBER;
       hash = (53 * hash) + getStartTimestamp().hashCode();
@@ -376,6 +386,17 @@ public  final class InternalMetrics extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.InternalMetrics parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.InternalMetrics parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.InternalMetrics parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -585,7 +606,7 @@ public  final class InternalMetrics extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -598,12 +619,12 @@ public  final class InternalMetrics extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -701,6 +722,7 @@ public  final class InternalMetrics extends
           }
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -732,13 +754,13 @@ public  final class InternalMetrics extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> startTimestampBuilder_;
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public boolean hasStartTimestamp() {
       return startTimestampBuilder_ != null || startTimestamp_ != null;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public com.google.protobuf.Timestamp getStartTimestamp() {
       if (startTimestampBuilder_ == null) {
@@ -748,7 +770,7 @@ public  final class InternalMetrics extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public Builder setStartTimestamp(com.google.protobuf.Timestamp value) {
       if (startTimestampBuilder_ == null) {
@@ -764,7 +786,7 @@ public  final class InternalMetrics extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public Builder setStartTimestamp(
         com.google.protobuf.Timestamp.Builder builderForValue) {
@@ -778,7 +800,7 @@ public  final class InternalMetrics extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public Builder mergeStartTimestamp(com.google.protobuf.Timestamp value) {
       if (startTimestampBuilder_ == null) {
@@ -796,7 +818,7 @@ public  final class InternalMetrics extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public Builder clearStartTimestamp() {
       if (startTimestampBuilder_ == null) {
@@ -810,7 +832,7 @@ public  final class InternalMetrics extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public com.google.protobuf.Timestamp.Builder getStartTimestampBuilder() {
       
@@ -818,7 +840,7 @@ public  final class InternalMetrics extends
       return getStartTimestampFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     public com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder() {
       if (startTimestampBuilder_ != null) {
@@ -829,7 +851,7 @@ public  final class InternalMetrics extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
@@ -847,13 +869,13 @@ public  final class InternalMetrics extends
 
     private long durationMicros_ ;
     /**
-     * <code>optional uint64 duration_micros = 2;</code>
+     * <code>uint64 duration_micros = 2;</code>
      */
     public long getDurationMicros() {
       return durationMicros_;
     }
     /**
-     * <code>optional uint64 duration_micros = 2;</code>
+     * <code>uint64 duration_micros = 2;</code>
      */
     public Builder setDurationMicros(long value) {
       
@@ -862,7 +884,7 @@ public  final class InternalMetrics extends
       return this;
     }
     /**
-     * <code>optional uint64 duration_micros = 2;</code>
+     * <code>uint64 duration_micros = 2;</code>
      */
     public Builder clearDurationMicros() {
       
@@ -1592,12 +1614,12 @@ public  final class InternalMetrics extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -1620,7 +1642,7 @@ public  final class InternalMetrics extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new InternalMetrics(input, extensionRegistry);
+      return new InternalMetrics(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/InternalMetricsOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/InternalMetricsOrBuilder.java
@@ -8,20 +8,20 @@ public interface InternalMetricsOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   boolean hasStartTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   com.google.protobuf.Timestamp getStartTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 1;</code>
    */
   com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder();
 
   /**
-   * <code>optional uint64 duration_micros = 2;</code>
+   * <code>uint64 duration_micros = 2;</code>
    */
   long getDurationMicros();
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/KeyValue.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/KeyValue.java
@@ -4,12 +4,17 @@
 package com.lightstep.tracer.grpc;
 
 /**
+ * <pre>
+ * Represent both tags and log fields.
+ * </pre>
+ *
  * Protobuf type {@code lightstep.collector.KeyValue}
  */
 public  final class KeyValue extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.KeyValue)
     KeyValueOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use KeyValue.newBuilder() to construct.
   private KeyValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -21,14 +26,19 @@ public  final class KeyValue extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private KeyValue(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +48,8 @@ public  final class KeyValue extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -84,6 +95,7 @@ public  final class KeyValue extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -146,7 +158,7 @@ public  final class KeyValue extends
   public static final int KEY_FIELD_NUMBER = 1;
   private volatile java.lang.Object key_;
   /**
-   * <code>optional string key = 1;</code>
+   * <code>string key = 1;</code>
    */
   public java.lang.String getKey() {
     java.lang.Object ref = key_;
@@ -161,7 +173,7 @@ public  final class KeyValue extends
     }
   }
   /**
-   * <code>optional string key = 1;</code>
+   * <code>string key = 1;</code>
    */
   public com.google.protobuf.ByteString
       getKeyBytes() {
@@ -184,7 +196,7 @@ public  final class KeyValue extends
    * json_value.
    * </pre>
    *
-   * <code>optional string string_value = 2;</code>
+   * <code>string string_value = 2;</code>
    */
   public java.lang.String getStringValue() {
     java.lang.Object ref = "";
@@ -209,7 +221,7 @@ public  final class KeyValue extends
    * json_value.
    * </pre>
    *
-   * <code>optional string string_value = 2;</code>
+   * <code>string string_value = 2;</code>
    */
   public com.google.protobuf.ByteString
       getStringValueBytes() {
@@ -232,7 +244,7 @@ public  final class KeyValue extends
 
   public static final int INT_VALUE_FIELD_NUMBER = 3;
   /**
-   * <code>optional int64 int_value = 3;</code>
+   * <code>int64 int_value = 3;</code>
    */
   public long getIntValue() {
     if (valueCase_ == 3) {
@@ -243,7 +255,7 @@ public  final class KeyValue extends
 
   public static final int DOUBLE_VALUE_FIELD_NUMBER = 4;
   /**
-   * <code>optional double double_value = 4;</code>
+   * <code>double double_value = 4;</code>
    */
   public double getDoubleValue() {
     if (valueCase_ == 4) {
@@ -254,7 +266,7 @@ public  final class KeyValue extends
 
   public static final int BOOL_VALUE_FIELD_NUMBER = 5;
   /**
-   * <code>optional bool bool_value = 5;</code>
+   * <code>bool bool_value = 5;</code>
    */
   public boolean getBoolValue() {
     if (valueCase_ == 5) {
@@ -267,10 +279,10 @@ public  final class KeyValue extends
   /**
    * <pre>
    * Must be a well-formed JSON value. Truncated JSON should go in
-   * string_value.
+   * string_value. Should not be used for tags.
    * </pre>
    *
-   * <code>optional string json_value = 6;</code>
+   * <code>string json_value = 6;</code>
    */
   public java.lang.String getJsonValue() {
     java.lang.Object ref = "";
@@ -292,10 +304,10 @@ public  final class KeyValue extends
   /**
    * <pre>
    * Must be a well-formed JSON value. Truncated JSON should go in
-   * string_value.
+   * string_value. Should not be used for tags.
    * </pre>
    *
-   * <code>optional string json_value = 6;</code>
+   * <code>string json_value = 6;</code>
    */
   public com.google.protobuf.ByteString
       getJsonValueBytes() {
@@ -349,6 +361,7 @@ public  final class KeyValue extends
     if (valueCase_ == 6) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 6, value_);
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -380,11 +393,11 @@ public  final class KeyValue extends
     if (valueCase_ == 6) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, value_);
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -427,6 +440,7 @@ public  final class KeyValue extends
       case 0:
       default:
     }
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -436,7 +450,7 @@ public  final class KeyValue extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + KEY_FIELD_NUMBER;
     hash = (53 * hash) + getKey().hashCode();
     switch (valueCase_) {
@@ -471,6 +485,17 @@ public  final class KeyValue extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.KeyValue parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.KeyValue parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.KeyValue parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -549,6 +574,10 @@ public  final class KeyValue extends
     return builder;
   }
   /**
+   * <pre>
+   * Represent both tags and log fields.
+   * </pre>
+   *
    * Protobuf type {@code lightstep.collector.KeyValue}
    */
   public static final class Builder extends
@@ -636,7 +665,7 @@ public  final class KeyValue extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -649,12 +678,12 @@ public  final class KeyValue extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -701,6 +730,7 @@ public  final class KeyValue extends
           break;
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -744,7 +774,7 @@ public  final class KeyValue extends
 
     private java.lang.Object key_ = "";
     /**
-     * <code>optional string key = 1;</code>
+     * <code>string key = 1;</code>
      */
     public java.lang.String getKey() {
       java.lang.Object ref = key_;
@@ -759,7 +789,7 @@ public  final class KeyValue extends
       }
     }
     /**
-     * <code>optional string key = 1;</code>
+     * <code>string key = 1;</code>
      */
     public com.google.protobuf.ByteString
         getKeyBytes() {
@@ -775,7 +805,7 @@ public  final class KeyValue extends
       }
     }
     /**
-     * <code>optional string key = 1;</code>
+     * <code>string key = 1;</code>
      */
     public Builder setKey(
         java.lang.String value) {
@@ -788,7 +818,7 @@ public  final class KeyValue extends
       return this;
     }
     /**
-     * <code>optional string key = 1;</code>
+     * <code>string key = 1;</code>
      */
     public Builder clearKey() {
       
@@ -797,7 +827,7 @@ public  final class KeyValue extends
       return this;
     }
     /**
-     * <code>optional string key = 1;</code>
+     * <code>string key = 1;</code>
      */
     public Builder setKeyBytes(
         com.google.protobuf.ByteString value) {
@@ -817,7 +847,7 @@ public  final class KeyValue extends
      * json_value.
      * </pre>
      *
-     * <code>optional string string_value = 2;</code>
+     * <code>string string_value = 2;</code>
      */
     public java.lang.String getStringValue() {
       java.lang.Object ref = "";
@@ -842,7 +872,7 @@ public  final class KeyValue extends
      * json_value.
      * </pre>
      *
-     * <code>optional string string_value = 2;</code>
+     * <code>string string_value = 2;</code>
      */
     public com.google.protobuf.ByteString
         getStringValueBytes() {
@@ -868,7 +898,7 @@ public  final class KeyValue extends
      * json_value.
      * </pre>
      *
-     * <code>optional string string_value = 2;</code>
+     * <code>string string_value = 2;</code>
      */
     public Builder setStringValue(
         java.lang.String value) {
@@ -886,7 +916,7 @@ public  final class KeyValue extends
      * json_value.
      * </pre>
      *
-     * <code>optional string string_value = 2;</code>
+     * <code>string string_value = 2;</code>
      */
     public Builder clearStringValue() {
       if (valueCase_ == 2) {
@@ -902,7 +932,7 @@ public  final class KeyValue extends
      * json_value.
      * </pre>
      *
-     * <code>optional string string_value = 2;</code>
+     * <code>string string_value = 2;</code>
      */
     public Builder setStringValueBytes(
         com.google.protobuf.ByteString value) {
@@ -917,7 +947,7 @@ public  final class KeyValue extends
     }
 
     /**
-     * <code>optional int64 int_value = 3;</code>
+     * <code>int64 int_value = 3;</code>
      */
     public long getIntValue() {
       if (valueCase_ == 3) {
@@ -926,7 +956,7 @@ public  final class KeyValue extends
       return 0L;
     }
     /**
-     * <code>optional int64 int_value = 3;</code>
+     * <code>int64 int_value = 3;</code>
      */
     public Builder setIntValue(long value) {
       valueCase_ = 3;
@@ -935,7 +965,7 @@ public  final class KeyValue extends
       return this;
     }
     /**
-     * <code>optional int64 int_value = 3;</code>
+     * <code>int64 int_value = 3;</code>
      */
     public Builder clearIntValue() {
       if (valueCase_ == 3) {
@@ -947,7 +977,7 @@ public  final class KeyValue extends
     }
 
     /**
-     * <code>optional double double_value = 4;</code>
+     * <code>double double_value = 4;</code>
      */
     public double getDoubleValue() {
       if (valueCase_ == 4) {
@@ -956,7 +986,7 @@ public  final class KeyValue extends
       return 0D;
     }
     /**
-     * <code>optional double double_value = 4;</code>
+     * <code>double double_value = 4;</code>
      */
     public Builder setDoubleValue(double value) {
       valueCase_ = 4;
@@ -965,7 +995,7 @@ public  final class KeyValue extends
       return this;
     }
     /**
-     * <code>optional double double_value = 4;</code>
+     * <code>double double_value = 4;</code>
      */
     public Builder clearDoubleValue() {
       if (valueCase_ == 4) {
@@ -977,7 +1007,7 @@ public  final class KeyValue extends
     }
 
     /**
-     * <code>optional bool bool_value = 5;</code>
+     * <code>bool bool_value = 5;</code>
      */
     public boolean getBoolValue() {
       if (valueCase_ == 5) {
@@ -986,7 +1016,7 @@ public  final class KeyValue extends
       return false;
     }
     /**
-     * <code>optional bool bool_value = 5;</code>
+     * <code>bool bool_value = 5;</code>
      */
     public Builder setBoolValue(boolean value) {
       valueCase_ = 5;
@@ -995,7 +1025,7 @@ public  final class KeyValue extends
       return this;
     }
     /**
-     * <code>optional bool bool_value = 5;</code>
+     * <code>bool bool_value = 5;</code>
      */
     public Builder clearBoolValue() {
       if (valueCase_ == 5) {
@@ -1009,10 +1039,10 @@ public  final class KeyValue extends
     /**
      * <pre>
      * Must be a well-formed JSON value. Truncated JSON should go in
-     * string_value.
+     * string_value. Should not be used for tags.
      * </pre>
      *
-     * <code>optional string json_value = 6;</code>
+     * <code>string json_value = 6;</code>
      */
     public java.lang.String getJsonValue() {
       java.lang.Object ref = "";
@@ -1034,10 +1064,10 @@ public  final class KeyValue extends
     /**
      * <pre>
      * Must be a well-formed JSON value. Truncated JSON should go in
-     * string_value.
+     * string_value. Should not be used for tags.
      * </pre>
      *
-     * <code>optional string json_value = 6;</code>
+     * <code>string json_value = 6;</code>
      */
     public com.google.protobuf.ByteString
         getJsonValueBytes() {
@@ -1060,10 +1090,10 @@ public  final class KeyValue extends
     /**
      * <pre>
      * Must be a well-formed JSON value. Truncated JSON should go in
-     * string_value.
+     * string_value. Should not be used for tags.
      * </pre>
      *
-     * <code>optional string json_value = 6;</code>
+     * <code>string json_value = 6;</code>
      */
     public Builder setJsonValue(
         java.lang.String value) {
@@ -1078,10 +1108,10 @@ public  final class KeyValue extends
     /**
      * <pre>
      * Must be a well-formed JSON value. Truncated JSON should go in
-     * string_value.
+     * string_value. Should not be used for tags.
      * </pre>
      *
-     * <code>optional string json_value = 6;</code>
+     * <code>string json_value = 6;</code>
      */
     public Builder clearJsonValue() {
       if (valueCase_ == 6) {
@@ -1094,10 +1124,10 @@ public  final class KeyValue extends
     /**
      * <pre>
      * Must be a well-formed JSON value. Truncated JSON should go in
-     * string_value.
+     * string_value. Should not be used for tags.
      * </pre>
      *
-     * <code>optional string json_value = 6;</code>
+     * <code>string json_value = 6;</code>
      */
     public Builder setJsonValueBytes(
         com.google.protobuf.ByteString value) {
@@ -1112,12 +1142,12 @@ public  final class KeyValue extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -1140,7 +1170,7 @@ public  final class KeyValue extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new KeyValue(input, extensionRegistry);
+      return new KeyValue(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/KeyValueOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/KeyValueOrBuilder.java
@@ -8,11 +8,11 @@ public interface KeyValueOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional string key = 1;</code>
+   * <code>string key = 1;</code>
    */
   java.lang.String getKey();
   /**
-   * <code>optional string key = 1;</code>
+   * <code>string key = 1;</code>
    */
   com.google.protobuf.ByteString
       getKeyBytes();
@@ -23,7 +23,7 @@ public interface KeyValueOrBuilder extends
    * json_value.
    * </pre>
    *
-   * <code>optional string string_value = 2;</code>
+   * <code>string string_value = 2;</code>
    */
   java.lang.String getStringValue();
   /**
@@ -32,42 +32,42 @@ public interface KeyValueOrBuilder extends
    * json_value.
    * </pre>
    *
-   * <code>optional string string_value = 2;</code>
+   * <code>string string_value = 2;</code>
    */
   com.google.protobuf.ByteString
       getStringValueBytes();
 
   /**
-   * <code>optional int64 int_value = 3;</code>
+   * <code>int64 int_value = 3;</code>
    */
   long getIntValue();
 
   /**
-   * <code>optional double double_value = 4;</code>
+   * <code>double double_value = 4;</code>
    */
   double getDoubleValue();
 
   /**
-   * <code>optional bool bool_value = 5;</code>
+   * <code>bool bool_value = 5;</code>
    */
   boolean getBoolValue();
 
   /**
    * <pre>
    * Must be a well-formed JSON value. Truncated JSON should go in
-   * string_value.
+   * string_value. Should not be used for tags.
    * </pre>
    *
-   * <code>optional string json_value = 6;</code>
+   * <code>string json_value = 6;</code>
    */
   java.lang.String getJsonValue();
   /**
    * <pre>
    * Must be a well-formed JSON value. Truncated JSON should go in
-   * string_value.
+   * string_value. Should not be used for tags.
    * </pre>
    *
-   * <code>optional string json_value = 6;</code>
+   * <code>string json_value = 6;</code>
    */
   com.google.protobuf.ByteString
       getJsonValueBytes();

--- a/common/src/main/java/com/lightstep/tracer/grpc/Log.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Log.java
@@ -10,25 +10,31 @@ public  final class Log extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Log)
     LogOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Log.newBuilder() to construct.
   private Log(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Log() {
-    keyvalues_ = java.util.Collections.emptyList();
+    fields_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Log(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +44,8 @@ public  final class Log extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -58,10 +65,10 @@ public  final class Log extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              keyvalues_ = new java.util.ArrayList<com.lightstep.tracer.grpc.KeyValue>();
+              fields_ = new java.util.ArrayList<com.lightstep.tracer.grpc.KeyValue>();
               mutable_bitField0_ |= 0x00000002;
             }
-            keyvalues_.add(
+            fields_.add(
                 input.readMessage(com.lightstep.tracer.grpc.KeyValue.parser(), extensionRegistry));
             break;
           }
@@ -74,8 +81,9 @@ public  final class Log extends
           e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-        keyvalues_ = java.util.Collections.unmodifiableList(keyvalues_);
+        fields_ = java.util.Collections.unmodifiableList(fields_);
       }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -95,57 +103,57 @@ public  final class Log extends
   public static final int TIMESTAMP_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp timestamp_;
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   public boolean hasTimestamp() {
     return timestamp_ != null;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   public com.google.protobuf.Timestamp getTimestamp() {
     return timestamp_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : timestamp_;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   public com.google.protobuf.TimestampOrBuilder getTimestampOrBuilder() {
     return getTimestamp();
   }
 
-  public static final int KEYVALUES_FIELD_NUMBER = 2;
-  private java.util.List<com.lightstep.tracer.grpc.KeyValue> keyvalues_;
+  public static final int FIELDS_FIELD_NUMBER = 2;
+  private java.util.List<com.lightstep.tracer.grpc.KeyValue> fields_;
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  public java.util.List<com.lightstep.tracer.grpc.KeyValue> getKeyvaluesList() {
-    return keyvalues_;
+  public java.util.List<com.lightstep.tracer.grpc.KeyValue> getFieldsList() {
+    return fields_;
   }
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
   public java.util.List<? extends com.lightstep.tracer.grpc.KeyValueOrBuilder> 
-      getKeyvaluesOrBuilderList() {
-    return keyvalues_;
+      getFieldsOrBuilderList() {
+    return fields_;
   }
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  public int getKeyvaluesCount() {
-    return keyvalues_.size();
+  public int getFieldsCount() {
+    return fields_.size();
   }
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  public com.lightstep.tracer.grpc.KeyValue getKeyvalues(int index) {
-    return keyvalues_.get(index);
+  public com.lightstep.tracer.grpc.KeyValue getFields(int index) {
+    return fields_.get(index);
   }
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  public com.lightstep.tracer.grpc.KeyValueOrBuilder getKeyvaluesOrBuilder(
+  public com.lightstep.tracer.grpc.KeyValueOrBuilder getFieldsOrBuilder(
       int index) {
-    return keyvalues_.get(index);
+    return fields_.get(index);
   }
 
   private byte memoizedIsInitialized = -1;
@@ -163,9 +171,10 @@ public  final class Log extends
     if (timestamp_ != null) {
       output.writeMessage(1, getTimestamp());
     }
-    for (int i = 0; i < keyvalues_.size(); i++) {
-      output.writeMessage(2, keyvalues_.get(i));
+    for (int i = 0; i < fields_.size(); i++) {
+      output.writeMessage(2, fields_.get(i));
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -177,15 +186,15 @@ public  final class Log extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getTimestamp());
     }
-    for (int i = 0; i < keyvalues_.size(); i++) {
+    for (int i = 0; i < fields_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, keyvalues_.get(i));
+        .computeMessageSize(2, fields_.get(i));
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -202,8 +211,9 @@ public  final class Log extends
       result = result && getTimestamp()
           .equals(other.getTimestamp());
     }
-    result = result && getKeyvaluesList()
-        .equals(other.getKeyvaluesList());
+    result = result && getFieldsList()
+        .equals(other.getFieldsList());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -213,20 +223,31 @@ public  final class Log extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     if (hasTimestamp()) {
       hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
       hash = (53 * hash) + getTimestamp().hashCode();
     }
-    if (getKeyvaluesCount() > 0) {
-      hash = (37 * hash) + KEYVALUES_FIELD_NUMBER;
-      hash = (53 * hash) + getKeyvaluesList().hashCode();
+    if (getFieldsCount() > 0) {
+      hash = (37 * hash) + FIELDS_FIELD_NUMBER;
+      hash = (53 * hash) + getFieldsList().hashCode();
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Log parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Log parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Log parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -336,7 +357,7 @@ public  final class Log extends
     private void maybeForceBuilderInitialization() {
       if (com.google.protobuf.GeneratedMessageV3
               .alwaysUseFieldBuilders) {
-        getKeyvaluesFieldBuilder();
+        getFieldsFieldBuilder();
       }
     }
     public Builder clear() {
@@ -347,11 +368,11 @@ public  final class Log extends
         timestamp_ = null;
         timestampBuilder_ = null;
       }
-      if (keyvaluesBuilder_ == null) {
-        keyvalues_ = java.util.Collections.emptyList();
+      if (fieldsBuilder_ == null) {
+        fields_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000002);
       } else {
-        keyvaluesBuilder_.clear();
+        fieldsBuilder_.clear();
       }
       return this;
     }
@@ -382,14 +403,14 @@ public  final class Log extends
       } else {
         result.timestamp_ = timestampBuilder_.build();
       }
-      if (keyvaluesBuilder_ == null) {
+      if (fieldsBuilder_ == null) {
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          keyvalues_ = java.util.Collections.unmodifiableList(keyvalues_);
+          fields_ = java.util.Collections.unmodifiableList(fields_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
-        result.keyvalues_ = keyvalues_;
+        result.fields_ = fields_;
       } else {
-        result.keyvalues_ = keyvaluesBuilder_.build();
+        result.fields_ = fieldsBuilder_.build();
       }
       result.bitField0_ = to_bitField0_;
       onBuilt();
@@ -401,7 +422,7 @@ public  final class Log extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -414,12 +435,12 @@ public  final class Log extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -436,32 +457,33 @@ public  final class Log extends
       if (other.hasTimestamp()) {
         mergeTimestamp(other.getTimestamp());
       }
-      if (keyvaluesBuilder_ == null) {
-        if (!other.keyvalues_.isEmpty()) {
-          if (keyvalues_.isEmpty()) {
-            keyvalues_ = other.keyvalues_;
+      if (fieldsBuilder_ == null) {
+        if (!other.fields_.isEmpty()) {
+          if (fields_.isEmpty()) {
+            fields_ = other.fields_;
             bitField0_ = (bitField0_ & ~0x00000002);
           } else {
-            ensureKeyvaluesIsMutable();
-            keyvalues_.addAll(other.keyvalues_);
+            ensureFieldsIsMutable();
+            fields_.addAll(other.fields_);
           }
           onChanged();
         }
       } else {
-        if (!other.keyvalues_.isEmpty()) {
-          if (keyvaluesBuilder_.isEmpty()) {
-            keyvaluesBuilder_.dispose();
-            keyvaluesBuilder_ = null;
-            keyvalues_ = other.keyvalues_;
+        if (!other.fields_.isEmpty()) {
+          if (fieldsBuilder_.isEmpty()) {
+            fieldsBuilder_.dispose();
+            fieldsBuilder_ = null;
+            fields_ = other.fields_;
             bitField0_ = (bitField0_ & ~0x00000002);
-            keyvaluesBuilder_ = 
+            fieldsBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getKeyvaluesFieldBuilder() : null;
+                 getFieldsFieldBuilder() : null;
           } else {
-            keyvaluesBuilder_.addAllMessages(other.keyvalues_);
+            fieldsBuilder_.addAllMessages(other.fields_);
           }
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -493,13 +515,13 @@ public  final class Log extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> timestampBuilder_;
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public boolean hasTimestamp() {
       return timestampBuilder_ != null || timestamp_ != null;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public com.google.protobuf.Timestamp getTimestamp() {
       if (timestampBuilder_ == null) {
@@ -509,7 +531,7 @@ public  final class Log extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public Builder setTimestamp(com.google.protobuf.Timestamp value) {
       if (timestampBuilder_ == null) {
@@ -525,7 +547,7 @@ public  final class Log extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public Builder setTimestamp(
         com.google.protobuf.Timestamp.Builder builderForValue) {
@@ -539,7 +561,7 @@ public  final class Log extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public Builder mergeTimestamp(com.google.protobuf.Timestamp value) {
       if (timestampBuilder_ == null) {
@@ -557,7 +579,7 @@ public  final class Log extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public Builder clearTimestamp() {
       if (timestampBuilder_ == null) {
@@ -571,7 +593,7 @@ public  final class Log extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public com.google.protobuf.Timestamp.Builder getTimestampBuilder() {
       
@@ -579,7 +601,7 @@ public  final class Log extends
       return getTimestampFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     public com.google.protobuf.TimestampOrBuilder getTimestampOrBuilder() {
       if (timestampBuilder_ != null) {
@@ -590,7 +612,7 @@ public  final class Log extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+     * <code>.google.protobuf.Timestamp timestamp = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
@@ -606,253 +628,253 @@ public  final class Log extends
       return timestampBuilder_;
     }
 
-    private java.util.List<com.lightstep.tracer.grpc.KeyValue> keyvalues_ =
+    private java.util.List<com.lightstep.tracer.grpc.KeyValue> fields_ =
       java.util.Collections.emptyList();
-    private void ensureKeyvaluesIsMutable() {
+    private void ensureFieldsIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        keyvalues_ = new java.util.ArrayList<com.lightstep.tracer.grpc.KeyValue>(keyvalues_);
+        fields_ = new java.util.ArrayList<com.lightstep.tracer.grpc.KeyValue>(fields_);
         bitField0_ |= 0x00000002;
        }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.lightstep.tracer.grpc.KeyValue, com.lightstep.tracer.grpc.KeyValue.Builder, com.lightstep.tracer.grpc.KeyValueOrBuilder> keyvaluesBuilder_;
+        com.lightstep.tracer.grpc.KeyValue, com.lightstep.tracer.grpc.KeyValue.Builder, com.lightstep.tracer.grpc.KeyValueOrBuilder> fieldsBuilder_;
 
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public java.util.List<com.lightstep.tracer.grpc.KeyValue> getKeyvaluesList() {
-      if (keyvaluesBuilder_ == null) {
-        return java.util.Collections.unmodifiableList(keyvalues_);
+    public java.util.List<com.lightstep.tracer.grpc.KeyValue> getFieldsList() {
+      if (fieldsBuilder_ == null) {
+        return java.util.Collections.unmodifiableList(fields_);
       } else {
-        return keyvaluesBuilder_.getMessageList();
+        return fieldsBuilder_.getMessageList();
       }
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public int getKeyvaluesCount() {
-      if (keyvaluesBuilder_ == null) {
-        return keyvalues_.size();
+    public int getFieldsCount() {
+      if (fieldsBuilder_ == null) {
+        return fields_.size();
       } else {
-        return keyvaluesBuilder_.getCount();
+        return fieldsBuilder_.getCount();
       }
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public com.lightstep.tracer.grpc.KeyValue getKeyvalues(int index) {
-      if (keyvaluesBuilder_ == null) {
-        return keyvalues_.get(index);
+    public com.lightstep.tracer.grpc.KeyValue getFields(int index) {
+      if (fieldsBuilder_ == null) {
+        return fields_.get(index);
       } else {
-        return keyvaluesBuilder_.getMessage(index);
+        return fieldsBuilder_.getMessage(index);
       }
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder setKeyvalues(
+    public Builder setFields(
         int index, com.lightstep.tracer.grpc.KeyValue value) {
-      if (keyvaluesBuilder_ == null) {
+      if (fieldsBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureKeyvaluesIsMutable();
-        keyvalues_.set(index, value);
+        ensureFieldsIsMutable();
+        fields_.set(index, value);
         onChanged();
       } else {
-        keyvaluesBuilder_.setMessage(index, value);
+        fieldsBuilder_.setMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder setKeyvalues(
+    public Builder setFields(
         int index, com.lightstep.tracer.grpc.KeyValue.Builder builderForValue) {
-      if (keyvaluesBuilder_ == null) {
-        ensureKeyvaluesIsMutable();
-        keyvalues_.set(index, builderForValue.build());
+      if (fieldsBuilder_ == null) {
+        ensureFieldsIsMutable();
+        fields_.set(index, builderForValue.build());
         onChanged();
       } else {
-        keyvaluesBuilder_.setMessage(index, builderForValue.build());
+        fieldsBuilder_.setMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder addKeyvalues(com.lightstep.tracer.grpc.KeyValue value) {
-      if (keyvaluesBuilder_ == null) {
+    public Builder addFields(com.lightstep.tracer.grpc.KeyValue value) {
+      if (fieldsBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureKeyvaluesIsMutable();
-        keyvalues_.add(value);
+        ensureFieldsIsMutable();
+        fields_.add(value);
         onChanged();
       } else {
-        keyvaluesBuilder_.addMessage(value);
+        fieldsBuilder_.addMessage(value);
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder addKeyvalues(
+    public Builder addFields(
         int index, com.lightstep.tracer.grpc.KeyValue value) {
-      if (keyvaluesBuilder_ == null) {
+      if (fieldsBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureKeyvaluesIsMutable();
-        keyvalues_.add(index, value);
+        ensureFieldsIsMutable();
+        fields_.add(index, value);
         onChanged();
       } else {
-        keyvaluesBuilder_.addMessage(index, value);
+        fieldsBuilder_.addMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder addKeyvalues(
+    public Builder addFields(
         com.lightstep.tracer.grpc.KeyValue.Builder builderForValue) {
-      if (keyvaluesBuilder_ == null) {
-        ensureKeyvaluesIsMutable();
-        keyvalues_.add(builderForValue.build());
+      if (fieldsBuilder_ == null) {
+        ensureFieldsIsMutable();
+        fields_.add(builderForValue.build());
         onChanged();
       } else {
-        keyvaluesBuilder_.addMessage(builderForValue.build());
+        fieldsBuilder_.addMessage(builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder addKeyvalues(
+    public Builder addFields(
         int index, com.lightstep.tracer.grpc.KeyValue.Builder builderForValue) {
-      if (keyvaluesBuilder_ == null) {
-        ensureKeyvaluesIsMutable();
-        keyvalues_.add(index, builderForValue.build());
+      if (fieldsBuilder_ == null) {
+        ensureFieldsIsMutable();
+        fields_.add(index, builderForValue.build());
         onChanged();
       } else {
-        keyvaluesBuilder_.addMessage(index, builderForValue.build());
+        fieldsBuilder_.addMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder addAllKeyvalues(
+    public Builder addAllFields(
         java.lang.Iterable<? extends com.lightstep.tracer.grpc.KeyValue> values) {
-      if (keyvaluesBuilder_ == null) {
-        ensureKeyvaluesIsMutable();
+      if (fieldsBuilder_ == null) {
+        ensureFieldsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, keyvalues_);
+            values, fields_);
         onChanged();
       } else {
-        keyvaluesBuilder_.addAllMessages(values);
+        fieldsBuilder_.addAllMessages(values);
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder clearKeyvalues() {
-      if (keyvaluesBuilder_ == null) {
-        keyvalues_ = java.util.Collections.emptyList();
+    public Builder clearFields() {
+      if (fieldsBuilder_ == null) {
+        fields_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
       } else {
-        keyvaluesBuilder_.clear();
+        fieldsBuilder_.clear();
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public Builder removeKeyvalues(int index) {
-      if (keyvaluesBuilder_ == null) {
-        ensureKeyvaluesIsMutable();
-        keyvalues_.remove(index);
+    public Builder removeFields(int index) {
+      if (fieldsBuilder_ == null) {
+        ensureFieldsIsMutable();
+        fields_.remove(index);
         onChanged();
       } else {
-        keyvaluesBuilder_.remove(index);
+        fieldsBuilder_.remove(index);
       }
       return this;
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public com.lightstep.tracer.grpc.KeyValue.Builder getKeyvaluesBuilder(
+    public com.lightstep.tracer.grpc.KeyValue.Builder getFieldsBuilder(
         int index) {
-      return getKeyvaluesFieldBuilder().getBuilder(index);
+      return getFieldsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public com.lightstep.tracer.grpc.KeyValueOrBuilder getKeyvaluesOrBuilder(
+    public com.lightstep.tracer.grpc.KeyValueOrBuilder getFieldsOrBuilder(
         int index) {
-      if (keyvaluesBuilder_ == null) {
-        return keyvalues_.get(index);  } else {
-        return keyvaluesBuilder_.getMessageOrBuilder(index);
+      if (fieldsBuilder_ == null) {
+        return fields_.get(index);  } else {
+        return fieldsBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
     public java.util.List<? extends com.lightstep.tracer.grpc.KeyValueOrBuilder> 
-         getKeyvaluesOrBuilderList() {
-      if (keyvaluesBuilder_ != null) {
-        return keyvaluesBuilder_.getMessageOrBuilderList();
+         getFieldsOrBuilderList() {
+      if (fieldsBuilder_ != null) {
+        return fieldsBuilder_.getMessageOrBuilderList();
       } else {
-        return java.util.Collections.unmodifiableList(keyvalues_);
+        return java.util.Collections.unmodifiableList(fields_);
       }
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public com.lightstep.tracer.grpc.KeyValue.Builder addKeyvaluesBuilder() {
-      return getKeyvaluesFieldBuilder().addBuilder(
+    public com.lightstep.tracer.grpc.KeyValue.Builder addFieldsBuilder() {
+      return getFieldsFieldBuilder().addBuilder(
           com.lightstep.tracer.grpc.KeyValue.getDefaultInstance());
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
-    public com.lightstep.tracer.grpc.KeyValue.Builder addKeyvaluesBuilder(
+    public com.lightstep.tracer.grpc.KeyValue.Builder addFieldsBuilder(
         int index) {
-      return getKeyvaluesFieldBuilder().addBuilder(
+      return getFieldsFieldBuilder().addBuilder(
           index, com.lightstep.tracer.grpc.KeyValue.getDefaultInstance());
     }
     /**
-     * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+     * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
      */
     public java.util.List<com.lightstep.tracer.grpc.KeyValue.Builder> 
-         getKeyvaluesBuilderList() {
-      return getKeyvaluesFieldBuilder().getBuilderList();
+         getFieldsBuilderList() {
+      return getFieldsFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
         com.lightstep.tracer.grpc.KeyValue, com.lightstep.tracer.grpc.KeyValue.Builder, com.lightstep.tracer.grpc.KeyValueOrBuilder> 
-        getKeyvaluesFieldBuilder() {
-      if (keyvaluesBuilder_ == null) {
-        keyvaluesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+        getFieldsFieldBuilder() {
+      if (fieldsBuilder_ == null) {
+        fieldsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.lightstep.tracer.grpc.KeyValue, com.lightstep.tracer.grpc.KeyValue.Builder, com.lightstep.tracer.grpc.KeyValueOrBuilder>(
-                keyvalues_,
+                fields_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),
                 isClean());
-        keyvalues_ = null;
+        fields_ = null;
       }
-      return keyvaluesBuilder_;
+      return fieldsBuilder_;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -875,7 +897,7 @@ public  final class Log extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Log(input, extensionRegistry);
+      return new Log(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/LogOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/LogOrBuilder.java
@@ -8,39 +8,39 @@ public interface LogOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   boolean hasTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   com.google.protobuf.Timestamp getTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp timestamp = 1;</code>
+   * <code>.google.protobuf.Timestamp timestamp = 1;</code>
    */
   com.google.protobuf.TimestampOrBuilder getTimestampOrBuilder();
 
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
   java.util.List<com.lightstep.tracer.grpc.KeyValue> 
-      getKeyvaluesList();
+      getFieldsList();
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  com.lightstep.tracer.grpc.KeyValue getKeyvalues(int index);
+  com.lightstep.tracer.grpc.KeyValue getFields(int index);
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  int getKeyvaluesCount();
+  int getFieldsCount();
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
   java.util.List<? extends com.lightstep.tracer.grpc.KeyValueOrBuilder> 
-      getKeyvaluesOrBuilderList();
+      getFieldsOrBuilderList();
   /**
-   * <code>repeated .lightstep.collector.KeyValue keyvalues = 2;</code>
+   * <code>repeated .lightstep.collector.KeyValue fields = 2;</code>
    */
-  com.lightstep.tracer.grpc.KeyValueOrBuilder getKeyvaluesOrBuilder(
+  com.lightstep.tracer.grpc.KeyValueOrBuilder getFieldsOrBuilder(
       int index);
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/MetricsSample.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/MetricsSample.java
@@ -10,6 +10,7 @@ public  final class MetricsSample extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.MetricsSample)
     MetricsSampleOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use MetricsSample.newBuilder() to construct.
   private MetricsSample(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -21,14 +22,19 @@ public  final class MetricsSample extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private MetricsSample(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +44,8 @@ public  final class MetricsSample extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -67,6 +74,7 @@ public  final class MetricsSample extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -123,7 +131,7 @@ public  final class MetricsSample extends
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
-   * <code>optional string name = 1;</code>
+   * <code>string name = 1;</code>
    */
   public java.lang.String getName() {
     java.lang.Object ref = name_;
@@ -138,7 +146,7 @@ public  final class MetricsSample extends
     }
   }
   /**
-   * <code>optional string name = 1;</code>
+   * <code>string name = 1;</code>
    */
   public com.google.protobuf.ByteString
       getNameBytes() {
@@ -156,7 +164,7 @@ public  final class MetricsSample extends
 
   public static final int INT_VALUE_FIELD_NUMBER = 2;
   /**
-   * <code>optional int64 int_value = 2;</code>
+   * <code>int64 int_value = 2;</code>
    */
   public long getIntValue() {
     if (valueCase_ == 2) {
@@ -167,7 +175,7 @@ public  final class MetricsSample extends
 
   public static final int DOUBLE_VALUE_FIELD_NUMBER = 3;
   /**
-   * <code>optional double double_value = 3;</code>
+   * <code>double double_value = 3;</code>
    */
   public double getDoubleValue() {
     if (valueCase_ == 3) {
@@ -199,6 +207,7 @@ public  final class MetricsSample extends
       output.writeDouble(
           3, (double)((java.lang.Double) value_));
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -219,11 +228,11 @@ public  final class MetricsSample extends
         .computeDoubleSize(
             3, (double)((java.lang.Double) value_));
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -254,6 +263,7 @@ public  final class MetricsSample extends
       case 0:
       default:
     }
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -263,7 +273,7 @@ public  final class MetricsSample extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + NAME_FIELD_NUMBER;
     hash = (53 * hash) + getName().hashCode();
     switch (valueCase_) {
@@ -285,6 +295,17 @@ public  final class MetricsSample extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.MetricsSample parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.MetricsSample parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.MetricsSample parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -441,7 +462,7 @@ public  final class MetricsSample extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -454,12 +475,12 @@ public  final class MetricsSample extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -490,6 +511,7 @@ public  final class MetricsSample extends
           break;
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -533,7 +555,7 @@ public  final class MetricsSample extends
 
     private java.lang.Object name_ = "";
     /**
-     * <code>optional string name = 1;</code>
+     * <code>string name = 1;</code>
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
@@ -548,7 +570,7 @@ public  final class MetricsSample extends
       }
     }
     /**
-     * <code>optional string name = 1;</code>
+     * <code>string name = 1;</code>
      */
     public com.google.protobuf.ByteString
         getNameBytes() {
@@ -564,7 +586,7 @@ public  final class MetricsSample extends
       }
     }
     /**
-     * <code>optional string name = 1;</code>
+     * <code>string name = 1;</code>
      */
     public Builder setName(
         java.lang.String value) {
@@ -577,7 +599,7 @@ public  final class MetricsSample extends
       return this;
     }
     /**
-     * <code>optional string name = 1;</code>
+     * <code>string name = 1;</code>
      */
     public Builder clearName() {
       
@@ -586,7 +608,7 @@ public  final class MetricsSample extends
       return this;
     }
     /**
-     * <code>optional string name = 1;</code>
+     * <code>string name = 1;</code>
      */
     public Builder setNameBytes(
         com.google.protobuf.ByteString value) {
@@ -601,7 +623,7 @@ public  final class MetricsSample extends
     }
 
     /**
-     * <code>optional int64 int_value = 2;</code>
+     * <code>int64 int_value = 2;</code>
      */
     public long getIntValue() {
       if (valueCase_ == 2) {
@@ -610,7 +632,7 @@ public  final class MetricsSample extends
       return 0L;
     }
     /**
-     * <code>optional int64 int_value = 2;</code>
+     * <code>int64 int_value = 2;</code>
      */
     public Builder setIntValue(long value) {
       valueCase_ = 2;
@@ -619,7 +641,7 @@ public  final class MetricsSample extends
       return this;
     }
     /**
-     * <code>optional int64 int_value = 2;</code>
+     * <code>int64 int_value = 2;</code>
      */
     public Builder clearIntValue() {
       if (valueCase_ == 2) {
@@ -631,7 +653,7 @@ public  final class MetricsSample extends
     }
 
     /**
-     * <code>optional double double_value = 3;</code>
+     * <code>double double_value = 3;</code>
      */
     public double getDoubleValue() {
       if (valueCase_ == 3) {
@@ -640,7 +662,7 @@ public  final class MetricsSample extends
       return 0D;
     }
     /**
-     * <code>optional double double_value = 3;</code>
+     * <code>double double_value = 3;</code>
      */
     public Builder setDoubleValue(double value) {
       valueCase_ = 3;
@@ -649,7 +671,7 @@ public  final class MetricsSample extends
       return this;
     }
     /**
-     * <code>optional double double_value = 3;</code>
+     * <code>double double_value = 3;</code>
      */
     public Builder clearDoubleValue() {
       if (valueCase_ == 3) {
@@ -661,12 +683,12 @@ public  final class MetricsSample extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -689,7 +711,7 @@ public  final class MetricsSample extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MetricsSample(input, extensionRegistry);
+      return new MetricsSample(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/MetricsSampleOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/MetricsSampleOrBuilder.java
@@ -8,22 +8,22 @@ public interface MetricsSampleOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional string name = 1;</code>
+   * <code>string name = 1;</code>
    */
   java.lang.String getName();
   /**
-   * <code>optional string name = 1;</code>
+   * <code>string name = 1;</code>
    */
   com.google.protobuf.ByteString
       getNameBytes();
 
   /**
-   * <code>optional int64 int_value = 2;</code>
+   * <code>int64 int_value = 2;</code>
    */
   long getIntValue();
 
   /**
-   * <code>optional double double_value = 3;</code>
+   * <code>double double_value = 3;</code>
    */
   double getDoubleValue();
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/Reference.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Reference.java
@@ -10,6 +10,7 @@ public  final class Reference extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Reference)
     ReferenceOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Reference.newBuilder() to construct.
   private Reference(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -21,14 +22,19 @@ public  final class Reference extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Reference(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -38,7 +44,8 @@ public  final class Reference extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -70,6 +77,7 @@ public  final class Reference extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -186,13 +194,13 @@ public  final class Reference extends
   public static final int RELATIONSHIP_FIELD_NUMBER = 1;
   private int relationship_;
   /**
-   * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+   * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
    */
   public int getRelationshipValue() {
     return relationship_;
   }
   /**
-   * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+   * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
    */
   public com.lightstep.tracer.grpc.Reference.Relationship getRelationship() {
     com.lightstep.tracer.grpc.Reference.Relationship result = com.lightstep.tracer.grpc.Reference.Relationship.valueOf(relationship_);
@@ -202,19 +210,19 @@ public  final class Reference extends
   public static final int SPAN_CONTEXT_FIELD_NUMBER = 2;
   private com.lightstep.tracer.grpc.SpanContext spanContext_;
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   public boolean hasSpanContext() {
     return spanContext_ != null;
   }
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   public com.lightstep.tracer.grpc.SpanContext getSpanContext() {
     return spanContext_ == null ? com.lightstep.tracer.grpc.SpanContext.getDefaultInstance() : spanContext_;
   }
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   public com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder() {
     return getSpanContext();
@@ -238,6 +246,7 @@ public  final class Reference extends
     if (spanContext_ != null) {
       output.writeMessage(2, getSpanContext());
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -253,11 +262,11 @@ public  final class Reference extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(2, getSpanContext());
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -275,6 +284,7 @@ public  final class Reference extends
       result = result && getSpanContext()
           .equals(other.getSpanContext());
     }
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -284,7 +294,7 @@ public  final class Reference extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + RELATIONSHIP_FIELD_NUMBER;
     hash = (53 * hash) + relationship_;
     if (hasSpanContext()) {
@@ -296,6 +306,17 @@ public  final class Reference extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Reference parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Reference parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Reference parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -454,7 +475,7 @@ public  final class Reference extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -467,12 +488,12 @@ public  final class Reference extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -492,6 +513,7 @@ public  final class Reference extends
       if (other.hasSpanContext()) {
         mergeSpanContext(other.getSpanContext());
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -520,13 +542,13 @@ public  final class Reference extends
 
     private int relationship_ = 0;
     /**
-     * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+     * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public int getRelationshipValue() {
       return relationship_;
     }
     /**
-     * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+     * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public Builder setRelationshipValue(int value) {
       relationship_ = value;
@@ -534,14 +556,14 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+     * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public com.lightstep.tracer.grpc.Reference.Relationship getRelationship() {
       com.lightstep.tracer.grpc.Reference.Relationship result = com.lightstep.tracer.grpc.Reference.Relationship.valueOf(relationship_);
       return result == null ? com.lightstep.tracer.grpc.Reference.Relationship.UNRECOGNIZED : result;
     }
     /**
-     * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+     * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public Builder setRelationship(com.lightstep.tracer.grpc.Reference.Relationship value) {
       if (value == null) {
@@ -553,7 +575,7 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+     * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public Builder clearRelationship() {
       
@@ -566,13 +588,13 @@ public  final class Reference extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.SpanContext, com.lightstep.tracer.grpc.SpanContext.Builder, com.lightstep.tracer.grpc.SpanContextOrBuilder> spanContextBuilder_;
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public boolean hasSpanContext() {
       return spanContextBuilder_ != null || spanContext_ != null;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public com.lightstep.tracer.grpc.SpanContext getSpanContext() {
       if (spanContextBuilder_ == null) {
@@ -582,7 +604,7 @@ public  final class Reference extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public Builder setSpanContext(com.lightstep.tracer.grpc.SpanContext value) {
       if (spanContextBuilder_ == null) {
@@ -598,7 +620,7 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public Builder setSpanContext(
         com.lightstep.tracer.grpc.SpanContext.Builder builderForValue) {
@@ -612,7 +634,7 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public Builder mergeSpanContext(com.lightstep.tracer.grpc.SpanContext value) {
       if (spanContextBuilder_ == null) {
@@ -630,7 +652,7 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public Builder clearSpanContext() {
       if (spanContextBuilder_ == null) {
@@ -644,7 +666,7 @@ public  final class Reference extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public com.lightstep.tracer.grpc.SpanContext.Builder getSpanContextBuilder() {
       
@@ -652,7 +674,7 @@ public  final class Reference extends
       return getSpanContextFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     public com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder() {
       if (spanContextBuilder_ != null) {
@@ -663,7 +685,7 @@ public  final class Reference extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.SpanContext, com.lightstep.tracer.grpc.SpanContext.Builder, com.lightstep.tracer.grpc.SpanContextOrBuilder> 
@@ -680,12 +702,12 @@ public  final class Reference extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -708,7 +730,7 @@ public  final class Reference extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Reference(input, extensionRegistry);
+      return new Reference(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReferenceOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReferenceOrBuilder.java
@@ -8,24 +8,24 @@ public interface ReferenceOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+   * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
    */
   int getRelationshipValue();
   /**
-   * <code>optional .lightstep.collector.Reference.Relationship relationship = 1;</code>
+   * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
    */
   com.lightstep.tracer.grpc.Reference.Relationship getRelationship();
 
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   boolean hasSpanContext();
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   com.lightstep.tracer.grpc.SpanContext getSpanContext();
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 2;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 2;</code>
    */
   com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder();
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportRequest.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportRequest.java
@@ -10,26 +10,32 @@ public  final class ReportRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.ReportRequest)
     ReportRequestOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use ReportRequest.newBuilder() to construct.
   private ReportRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReportRequest() {
     spans_ = java.util.Collections.emptyList();
-    timestampOffsetMicros_ = 0;
+    timestampOffsetMicros_ = 0L;
   }
 
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private ReportRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -39,7 +45,8 @@ public  final class ReportRequest extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -81,7 +88,7 @@ public  final class ReportRequest extends
           }
           case 40: {
 
-            timestampOffsetMicros_ = input.readUInt32();
+            timestampOffsetMicros_ = input.readInt64();
             break;
           }
           case 50: {
@@ -108,6 +115,7 @@ public  final class ReportRequest extends
       if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
         spans_ = java.util.Collections.unmodifiableList(spans_);
       }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -127,19 +135,19 @@ public  final class ReportRequest extends
   public static final int REPORTER_FIELD_NUMBER = 1;
   private com.lightstep.tracer.grpc.Reporter reporter_;
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   public boolean hasReporter() {
     return reporter_ != null;
   }
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   public com.lightstep.tracer.grpc.Reporter getReporter() {
     return reporter_ == null ? com.lightstep.tracer.grpc.Reporter.getDefaultInstance() : reporter_;
   }
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   public com.lightstep.tracer.grpc.ReporterOrBuilder getReporterOrBuilder() {
     return getReporter();
@@ -148,19 +156,19 @@ public  final class ReportRequest extends
   public static final int AUTH_FIELD_NUMBER = 2;
   private com.lightstep.tracer.grpc.Auth auth_;
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   public boolean hasAuth() {
     return auth_ != null;
   }
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   public com.lightstep.tracer.grpc.Auth getAuth() {
     return auth_ == null ? com.lightstep.tracer.grpc.Auth.getDefaultInstance() : auth_;
   }
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   public com.lightstep.tracer.grpc.AuthOrBuilder getAuthOrBuilder() {
     return getAuth();
@@ -202,30 +210,30 @@ public  final class ReportRequest extends
   }
 
   public static final int TIMESTAMP_OFFSET_MICROS_FIELD_NUMBER = 5;
-  private int timestampOffsetMicros_;
+  private long timestampOffsetMicros_;
   /**
-   * <code>optional uint32 timestamp_offset_micros = 5;</code>
+   * <code>int64 timestamp_offset_micros = 5;</code>
    */
-  public int getTimestampOffsetMicros() {
+  public long getTimestampOffsetMicros() {
     return timestampOffsetMicros_;
   }
 
   public static final int INTERNAL_METRICS_FIELD_NUMBER = 6;
   private com.lightstep.tracer.grpc.InternalMetrics internalMetrics_;
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   public boolean hasInternalMetrics() {
     return internalMetrics_ != null;
   }
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   public com.lightstep.tracer.grpc.InternalMetrics getInternalMetrics() {
     return internalMetrics_ == null ? com.lightstep.tracer.grpc.InternalMetrics.getDefaultInstance() : internalMetrics_;
   }
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   public com.lightstep.tracer.grpc.InternalMetricsOrBuilder getInternalMetricsOrBuilder() {
     return getInternalMetrics();
@@ -252,12 +260,13 @@ public  final class ReportRequest extends
     for (int i = 0; i < spans_.size(); i++) {
       output.writeMessage(3, spans_.get(i));
     }
-    if (timestampOffsetMicros_ != 0) {
-      output.writeUInt32(5, timestampOffsetMicros_);
+    if (timestampOffsetMicros_ != 0L) {
+      output.writeInt64(5, timestampOffsetMicros_);
     }
     if (internalMetrics_ != null) {
       output.writeMessage(6, getInternalMetrics());
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -277,19 +286,19 @@ public  final class ReportRequest extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, spans_.get(i));
     }
-    if (timestampOffsetMicros_ != 0) {
+    if (timestampOffsetMicros_ != 0L) {
       size += com.google.protobuf.CodedOutputStream
-        .computeUInt32Size(5, timestampOffsetMicros_);
+        .computeInt64Size(5, timestampOffsetMicros_);
     }
     if (internalMetrics_ != null) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getInternalMetrics());
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -320,6 +329,7 @@ public  final class ReportRequest extends
       result = result && getInternalMetrics()
           .equals(other.getInternalMetrics());
     }
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -329,7 +339,7 @@ public  final class ReportRequest extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     if (hasReporter()) {
       hash = (37 * hash) + REPORTER_FIELD_NUMBER;
       hash = (53 * hash) + getReporter().hashCode();
@@ -343,7 +353,8 @@ public  final class ReportRequest extends
       hash = (53 * hash) + getSpansList().hashCode();
     }
     hash = (37 * hash) + TIMESTAMP_OFFSET_MICROS_FIELD_NUMBER;
-    hash = (53 * hash) + getTimestampOffsetMicros();
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getTimestampOffsetMicros());
     if (hasInternalMetrics()) {
       hash = (37 * hash) + INTERNAL_METRICS_FIELD_NUMBER;
       hash = (53 * hash) + getInternalMetrics().hashCode();
@@ -353,6 +364,17 @@ public  final class ReportRequest extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.ReportRequest parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.ReportRequest parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.ReportRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -485,7 +507,7 @@ public  final class ReportRequest extends
       } else {
         spansBuilder_.clear();
       }
-      timestampOffsetMicros_ = 0;
+      timestampOffsetMicros_ = 0L;
 
       if (internalMetricsBuilder_ == null) {
         internalMetrics_ = null;
@@ -552,7 +574,7 @@ public  final class ReportRequest extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -565,12 +587,12 @@ public  final class ReportRequest extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -616,12 +638,13 @@ public  final class ReportRequest extends
           }
         }
       }
-      if (other.getTimestampOffsetMicros() != 0) {
+      if (other.getTimestampOffsetMicros() != 0L) {
         setTimestampOffsetMicros(other.getTimestampOffsetMicros());
       }
       if (other.hasInternalMetrics()) {
         mergeInternalMetrics(other.getInternalMetrics());
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -653,13 +676,13 @@ public  final class ReportRequest extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.Reporter, com.lightstep.tracer.grpc.Reporter.Builder, com.lightstep.tracer.grpc.ReporterOrBuilder> reporterBuilder_;
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public boolean hasReporter() {
       return reporterBuilder_ != null || reporter_ != null;
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public com.lightstep.tracer.grpc.Reporter getReporter() {
       if (reporterBuilder_ == null) {
@@ -669,7 +692,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public Builder setReporter(com.lightstep.tracer.grpc.Reporter value) {
       if (reporterBuilder_ == null) {
@@ -685,7 +708,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public Builder setReporter(
         com.lightstep.tracer.grpc.Reporter.Builder builderForValue) {
@@ -699,7 +722,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public Builder mergeReporter(com.lightstep.tracer.grpc.Reporter value) {
       if (reporterBuilder_ == null) {
@@ -717,7 +740,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public Builder clearReporter() {
       if (reporterBuilder_ == null) {
@@ -731,7 +754,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public com.lightstep.tracer.grpc.Reporter.Builder getReporterBuilder() {
       
@@ -739,7 +762,7 @@ public  final class ReportRequest extends
       return getReporterFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     public com.lightstep.tracer.grpc.ReporterOrBuilder getReporterOrBuilder() {
       if (reporterBuilder_ != null) {
@@ -750,7 +773,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+     * <code>.lightstep.collector.Reporter reporter = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.Reporter, com.lightstep.tracer.grpc.Reporter.Builder, com.lightstep.tracer.grpc.ReporterOrBuilder> 
@@ -770,13 +793,13 @@ public  final class ReportRequest extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.Auth, com.lightstep.tracer.grpc.Auth.Builder, com.lightstep.tracer.grpc.AuthOrBuilder> authBuilder_;
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public boolean hasAuth() {
       return authBuilder_ != null || auth_ != null;
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public com.lightstep.tracer.grpc.Auth getAuth() {
       if (authBuilder_ == null) {
@@ -786,7 +809,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public Builder setAuth(com.lightstep.tracer.grpc.Auth value) {
       if (authBuilder_ == null) {
@@ -802,7 +825,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public Builder setAuth(
         com.lightstep.tracer.grpc.Auth.Builder builderForValue) {
@@ -816,7 +839,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public Builder mergeAuth(com.lightstep.tracer.grpc.Auth value) {
       if (authBuilder_ == null) {
@@ -834,7 +857,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public Builder clearAuth() {
       if (authBuilder_ == null) {
@@ -848,7 +871,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public com.lightstep.tracer.grpc.Auth.Builder getAuthBuilder() {
       
@@ -856,7 +879,7 @@ public  final class ReportRequest extends
       return getAuthFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     public com.lightstep.tracer.grpc.AuthOrBuilder getAuthOrBuilder() {
       if (authBuilder_ != null) {
@@ -867,7 +890,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.Auth auth = 2;</code>
+     * <code>.lightstep.collector.Auth auth = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.Auth, com.lightstep.tracer.grpc.Auth.Builder, com.lightstep.tracer.grpc.AuthOrBuilder> 
@@ -1123,28 +1146,28 @@ public  final class ReportRequest extends
       return spansBuilder_;
     }
 
-    private int timestampOffsetMicros_ ;
+    private long timestampOffsetMicros_ ;
     /**
-     * <code>optional uint32 timestamp_offset_micros = 5;</code>
+     * <code>int64 timestamp_offset_micros = 5;</code>
      */
-    public int getTimestampOffsetMicros() {
+    public long getTimestampOffsetMicros() {
       return timestampOffsetMicros_;
     }
     /**
-     * <code>optional uint32 timestamp_offset_micros = 5;</code>
+     * <code>int64 timestamp_offset_micros = 5;</code>
      */
-    public Builder setTimestampOffsetMicros(int value) {
+    public Builder setTimestampOffsetMicros(long value) {
       
       timestampOffsetMicros_ = value;
       onChanged();
       return this;
     }
     /**
-     * <code>optional uint32 timestamp_offset_micros = 5;</code>
+     * <code>int64 timestamp_offset_micros = 5;</code>
      */
     public Builder clearTimestampOffsetMicros() {
       
-      timestampOffsetMicros_ = 0;
+      timestampOffsetMicros_ = 0L;
       onChanged();
       return this;
     }
@@ -1153,13 +1176,13 @@ public  final class ReportRequest extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.InternalMetrics, com.lightstep.tracer.grpc.InternalMetrics.Builder, com.lightstep.tracer.grpc.InternalMetricsOrBuilder> internalMetricsBuilder_;
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public boolean hasInternalMetrics() {
       return internalMetricsBuilder_ != null || internalMetrics_ != null;
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public com.lightstep.tracer.grpc.InternalMetrics getInternalMetrics() {
       if (internalMetricsBuilder_ == null) {
@@ -1169,7 +1192,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public Builder setInternalMetrics(com.lightstep.tracer.grpc.InternalMetrics value) {
       if (internalMetricsBuilder_ == null) {
@@ -1185,7 +1208,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public Builder setInternalMetrics(
         com.lightstep.tracer.grpc.InternalMetrics.Builder builderForValue) {
@@ -1199,7 +1222,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public Builder mergeInternalMetrics(com.lightstep.tracer.grpc.InternalMetrics value) {
       if (internalMetricsBuilder_ == null) {
@@ -1217,7 +1240,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public Builder clearInternalMetrics() {
       if (internalMetricsBuilder_ == null) {
@@ -1231,7 +1254,7 @@ public  final class ReportRequest extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public com.lightstep.tracer.grpc.InternalMetrics.Builder getInternalMetricsBuilder() {
       
@@ -1239,7 +1262,7 @@ public  final class ReportRequest extends
       return getInternalMetricsFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     public com.lightstep.tracer.grpc.InternalMetricsOrBuilder getInternalMetricsOrBuilder() {
       if (internalMetricsBuilder_ != null) {
@@ -1250,7 +1273,7 @@ public  final class ReportRequest extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+     * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.InternalMetrics, com.lightstep.tracer.grpc.InternalMetrics.Builder, com.lightstep.tracer.grpc.InternalMetricsOrBuilder> 
@@ -1267,12 +1290,12 @@ public  final class ReportRequest extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -1295,7 +1318,7 @@ public  final class ReportRequest extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReportRequest(input, extensionRegistry);
+      return new ReportRequest(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportRequestOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportRequestOrBuilder.java
@@ -8,28 +8,28 @@ public interface ReportRequestOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   boolean hasReporter();
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   com.lightstep.tracer.grpc.Reporter getReporter();
   /**
-   * <code>optional .lightstep.collector.Reporter reporter = 1;</code>
+   * <code>.lightstep.collector.Reporter reporter = 1;</code>
    */
   com.lightstep.tracer.grpc.ReporterOrBuilder getReporterOrBuilder();
 
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   boolean hasAuth();
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   com.lightstep.tracer.grpc.Auth getAuth();
   /**
-   * <code>optional .lightstep.collector.Auth auth = 2;</code>
+   * <code>.lightstep.collector.Auth auth = 2;</code>
    */
   com.lightstep.tracer.grpc.AuthOrBuilder getAuthOrBuilder();
 
@@ -58,20 +58,20 @@ public interface ReportRequestOrBuilder extends
       int index);
 
   /**
-   * <code>optional uint32 timestamp_offset_micros = 5;</code>
+   * <code>int64 timestamp_offset_micros = 5;</code>
    */
-  int getTimestampOffsetMicros();
+  long getTimestampOffsetMicros();
 
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   boolean hasInternalMetrics();
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   com.lightstep.tracer.grpc.InternalMetrics getInternalMetrics();
   /**
-   * <code>optional .lightstep.collector.InternalMetrics internal_metrics = 6;</code>
+   * <code>.lightstep.collector.InternalMetrics internal_metrics = 6;</code>
    */
   com.lightstep.tracer.grpc.InternalMetricsOrBuilder getInternalMetricsOrBuilder();
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportResponse.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportResponse.java
@@ -10,6 +10,7 @@ public  final class ReportResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.ReportResponse)
     ReportResponseOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use ReportResponse.newBuilder() to construct.
   private ReportResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -17,19 +18,26 @@ public  final class ReportResponse extends
   private ReportResponse() {
     commands_ = java.util.Collections.emptyList();
     errors_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    warnings_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    infos_ = com.google.protobuf.LazyStringArrayList.EMPTY;
   }
 
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private ReportResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -39,7 +47,8 @@ public  final class ReportResponse extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -88,6 +97,24 @@ public  final class ReportResponse extends
             errors_.add(s);
             break;
           }
+          case 42: {
+            java.lang.String s = input.readStringRequireUtf8();
+            if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              warnings_ = new com.google.protobuf.LazyStringArrayList();
+              mutable_bitField0_ |= 0x00000010;
+            }
+            warnings_.add(s);
+            break;
+          }
+          case 50: {
+            java.lang.String s = input.readStringRequireUtf8();
+            if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              infos_ = new com.google.protobuf.LazyStringArrayList();
+              mutable_bitField0_ |= 0x00000020;
+            }
+            infos_.add(s);
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -102,6 +129,13 @@ public  final class ReportResponse extends
       if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
         errors_ = errors_.getUnmodifiableView();
       }
+      if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+        warnings_ = warnings_.getUnmodifiableView();
+      }
+      if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        infos_ = infos_.getUnmodifiableView();
+      }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -156,19 +190,19 @@ public  final class ReportResponse extends
   public static final int RECEIVE_TIMESTAMP_FIELD_NUMBER = 2;
   private com.google.protobuf.Timestamp receiveTimestamp_;
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   public boolean hasReceiveTimestamp() {
     return receiveTimestamp_ != null;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   public com.google.protobuf.Timestamp getReceiveTimestamp() {
     return receiveTimestamp_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : receiveTimestamp_;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   public com.google.protobuf.TimestampOrBuilder getReceiveTimestampOrBuilder() {
     return getReceiveTimestamp();
@@ -177,19 +211,19 @@ public  final class ReportResponse extends
   public static final int TRANSMIT_TIMESTAMP_FIELD_NUMBER = 3;
   private com.google.protobuf.Timestamp transmitTimestamp_;
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   public boolean hasTransmitTimestamp() {
     return transmitTimestamp_ != null;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   public com.google.protobuf.Timestamp getTransmitTimestamp() {
     return transmitTimestamp_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : transmitTimestamp_;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   public com.google.protobuf.TimestampOrBuilder getTransmitTimestampOrBuilder() {
     return getTransmitTimestamp();
@@ -224,6 +258,64 @@ public  final class ReportResponse extends
     return errors_.getByteString(index);
   }
 
+  public static final int WARNINGS_FIELD_NUMBER = 5;
+  private com.google.protobuf.LazyStringList warnings_;
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  public com.google.protobuf.ProtocolStringList
+      getWarningsList() {
+    return warnings_;
+  }
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  public int getWarningsCount() {
+    return warnings_.size();
+  }
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  public java.lang.String getWarnings(int index) {
+    return warnings_.get(index);
+  }
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  public com.google.protobuf.ByteString
+      getWarningsBytes(int index) {
+    return warnings_.getByteString(index);
+  }
+
+  public static final int INFOS_FIELD_NUMBER = 6;
+  private com.google.protobuf.LazyStringList infos_;
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  public com.google.protobuf.ProtocolStringList
+      getInfosList() {
+    return infos_;
+  }
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  public int getInfosCount() {
+    return infos_.size();
+  }
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  public java.lang.String getInfos(int index) {
+    return infos_.get(index);
+  }
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  public com.google.protobuf.ByteString
+      getInfosBytes(int index) {
+    return infos_.getByteString(index);
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -248,6 +340,13 @@ public  final class ReportResponse extends
     for (int i = 0; i < errors_.size(); i++) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 4, errors_.getRaw(i));
     }
+    for (int i = 0; i < warnings_.size(); i++) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 5, warnings_.getRaw(i));
+    }
+    for (int i = 0; i < infos_.size(); i++) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 6, infos_.getRaw(i));
+    }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -275,11 +374,27 @@ public  final class ReportResponse extends
       size += dataSize;
       size += 1 * getErrorsList().size();
     }
+    {
+      int dataSize = 0;
+      for (int i = 0; i < warnings_.size(); i++) {
+        dataSize += computeStringSizeNoTag(warnings_.getRaw(i));
+      }
+      size += dataSize;
+      size += 1 * getWarningsList().size();
+    }
+    {
+      int dataSize = 0;
+      for (int i = 0; i < infos_.size(); i++) {
+        dataSize += computeStringSizeNoTag(infos_.getRaw(i));
+      }
+      size += dataSize;
+      size += 1 * getInfosList().size();
+    }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -305,6 +420,11 @@ public  final class ReportResponse extends
     }
     result = result && getErrorsList()
         .equals(other.getErrorsList());
+    result = result && getWarningsList()
+        .equals(other.getWarningsList());
+    result = result && getInfosList()
+        .equals(other.getInfosList());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -314,7 +434,7 @@ public  final class ReportResponse extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     if (getCommandsCount() > 0) {
       hash = (37 * hash) + COMMANDS_FIELD_NUMBER;
       hash = (53 * hash) + getCommandsList().hashCode();
@@ -331,11 +451,30 @@ public  final class ReportResponse extends
       hash = (37 * hash) + ERRORS_FIELD_NUMBER;
       hash = (53 * hash) + getErrorsList().hashCode();
     }
+    if (getWarningsCount() > 0) {
+      hash = (37 * hash) + WARNINGS_FIELD_NUMBER;
+      hash = (53 * hash) + getWarningsList().hashCode();
+    }
+    if (getInfosCount() > 0) {
+      hash = (37 * hash) + INFOS_FIELD_NUMBER;
+      hash = (53 * hash) + getInfosList().hashCode();
+    }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.ReportResponse parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.ReportResponse parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.ReportResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -470,6 +609,10 @@ public  final class ReportResponse extends
       }
       errors_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       bitField0_ = (bitField0_ & ~0x00000008);
+      warnings_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000010);
+      infos_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000020);
       return this;
     }
 
@@ -518,6 +661,16 @@ public  final class ReportResponse extends
         bitField0_ = (bitField0_ & ~0x00000008);
       }
       result.errors_ = errors_;
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        warnings_ = warnings_.getUnmodifiableView();
+        bitField0_ = (bitField0_ & ~0x00000010);
+      }
+      result.warnings_ = warnings_;
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        infos_ = infos_.getUnmodifiableView();
+        bitField0_ = (bitField0_ & ~0x00000020);
+      }
+      result.infos_ = infos_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -528,7 +681,7 @@ public  final class ReportResponse extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -541,12 +694,12 @@ public  final class ReportResponse extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -602,6 +755,27 @@ public  final class ReportResponse extends
         }
         onChanged();
       }
+      if (!other.warnings_.isEmpty()) {
+        if (warnings_.isEmpty()) {
+          warnings_ = other.warnings_;
+          bitField0_ = (bitField0_ & ~0x00000010);
+        } else {
+          ensureWarningsIsMutable();
+          warnings_.addAll(other.warnings_);
+        }
+        onChanged();
+      }
+      if (!other.infos_.isEmpty()) {
+        if (infos_.isEmpty()) {
+          infos_ = other.infos_;
+          bitField0_ = (bitField0_ & ~0x00000020);
+        } else {
+          ensureInfosIsMutable();
+          infos_.addAll(other.infos_);
+        }
+        onChanged();
+      }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -873,13 +1047,13 @@ public  final class ReportResponse extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> receiveTimestampBuilder_;
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public boolean hasReceiveTimestamp() {
       return receiveTimestampBuilder_ != null || receiveTimestamp_ != null;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public com.google.protobuf.Timestamp getReceiveTimestamp() {
       if (receiveTimestampBuilder_ == null) {
@@ -889,7 +1063,7 @@ public  final class ReportResponse extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public Builder setReceiveTimestamp(com.google.protobuf.Timestamp value) {
       if (receiveTimestampBuilder_ == null) {
@@ -905,7 +1079,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public Builder setReceiveTimestamp(
         com.google.protobuf.Timestamp.Builder builderForValue) {
@@ -919,7 +1093,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public Builder mergeReceiveTimestamp(com.google.protobuf.Timestamp value) {
       if (receiveTimestampBuilder_ == null) {
@@ -937,7 +1111,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public Builder clearReceiveTimestamp() {
       if (receiveTimestampBuilder_ == null) {
@@ -951,7 +1125,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public com.google.protobuf.Timestamp.Builder getReceiveTimestampBuilder() {
       
@@ -959,7 +1133,7 @@ public  final class ReportResponse extends
       return getReceiveTimestampFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     public com.google.protobuf.TimestampOrBuilder getReceiveTimestampOrBuilder() {
       if (receiveTimestampBuilder_ != null) {
@@ -970,7 +1144,7 @@ public  final class ReportResponse extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+     * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
@@ -990,13 +1164,13 @@ public  final class ReportResponse extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> transmitTimestampBuilder_;
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public boolean hasTransmitTimestamp() {
       return transmitTimestampBuilder_ != null || transmitTimestamp_ != null;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public com.google.protobuf.Timestamp getTransmitTimestamp() {
       if (transmitTimestampBuilder_ == null) {
@@ -1006,7 +1180,7 @@ public  final class ReportResponse extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public Builder setTransmitTimestamp(com.google.protobuf.Timestamp value) {
       if (transmitTimestampBuilder_ == null) {
@@ -1022,7 +1196,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public Builder setTransmitTimestamp(
         com.google.protobuf.Timestamp.Builder builderForValue) {
@@ -1036,7 +1210,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public Builder mergeTransmitTimestamp(com.google.protobuf.Timestamp value) {
       if (transmitTimestampBuilder_ == null) {
@@ -1054,7 +1228,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public Builder clearTransmitTimestamp() {
       if (transmitTimestampBuilder_ == null) {
@@ -1068,7 +1242,7 @@ public  final class ReportResponse extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public com.google.protobuf.Timestamp.Builder getTransmitTimestampBuilder() {
       
@@ -1076,7 +1250,7 @@ public  final class ReportResponse extends
       return getTransmitTimestampFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     public com.google.protobuf.TimestampOrBuilder getTransmitTimestampOrBuilder() {
       if (transmitTimestampBuilder_ != null) {
@@ -1087,7 +1261,7 @@ public  final class ReportResponse extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+     * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
@@ -1196,14 +1370,202 @@ public  final class ReportResponse extends
       onChanged();
       return this;
     }
+
+    private com.google.protobuf.LazyStringList warnings_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private void ensureWarningsIsMutable() {
+      if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        warnings_ = new com.google.protobuf.LazyStringArrayList(warnings_);
+        bitField0_ |= 0x00000010;
+       }
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getWarningsList() {
+      return warnings_.getUnmodifiableView();
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public int getWarningsCount() {
+      return warnings_.size();
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public java.lang.String getWarnings(int index) {
+      return warnings_.get(index);
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getWarningsBytes(int index) {
+      return warnings_.getByteString(index);
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public Builder setWarnings(
+        int index, java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureWarningsIsMutable();
+      warnings_.set(index, value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public Builder addWarnings(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureWarningsIsMutable();
+      warnings_.add(value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public Builder addAllWarnings(
+        java.lang.Iterable<java.lang.String> values) {
+      ensureWarningsIsMutable();
+      com.google.protobuf.AbstractMessageLite.Builder.addAll(
+          values, warnings_);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public Builder clearWarnings() {
+      warnings_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000010);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string warnings = 5;</code>
+     */
+    public Builder addWarningsBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      ensureWarningsIsMutable();
+      warnings_.add(value);
+      onChanged();
+      return this;
+    }
+
+    private com.google.protobuf.LazyStringList infos_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private void ensureInfosIsMutable() {
+      if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        infos_ = new com.google.protobuf.LazyStringArrayList(infos_);
+        bitField0_ |= 0x00000020;
+       }
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getInfosList() {
+      return infos_.getUnmodifiableView();
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public int getInfosCount() {
+      return infos_.size();
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public java.lang.String getInfos(int index) {
+      return infos_.get(index);
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getInfosBytes(int index) {
+      return infos_.getByteString(index);
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public Builder setInfos(
+        int index, java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureInfosIsMutable();
+      infos_.set(index, value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public Builder addInfos(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureInfosIsMutable();
+      infos_.add(value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public Builder addAllInfos(
+        java.lang.Iterable<java.lang.String> values) {
+      ensureInfosIsMutable();
+      com.google.protobuf.AbstractMessageLite.Builder.addAll(
+          values, infos_);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public Builder clearInfos() {
+      infos_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000020);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string infos = 6;</code>
+     */
+    public Builder addInfosBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      ensureInfosIsMutable();
+      infos_.add(value);
+      onChanged();
+      return this;
+    }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -1226,7 +1588,7 @@ public  final class ReportResponse extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReportResponse(input, extensionRegistry);
+      return new ReportResponse(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportResponseOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportResponseOrBuilder.java
@@ -32,28 +32,28 @@ public interface ReportResponseOrBuilder extends
       int index);
 
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   boolean hasReceiveTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   com.google.protobuf.Timestamp getReceiveTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp receive_timestamp = 2;</code>
+   * <code>.google.protobuf.Timestamp receive_timestamp = 2;</code>
    */
   com.google.protobuf.TimestampOrBuilder getReceiveTimestampOrBuilder();
 
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   boolean hasTransmitTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   com.google.protobuf.Timestamp getTransmitTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp transmit_timestamp = 3;</code>
+   * <code>.google.protobuf.Timestamp transmit_timestamp = 3;</code>
    */
   com.google.protobuf.TimestampOrBuilder getTransmitTimestampOrBuilder();
 
@@ -75,4 +75,42 @@ public interface ReportResponseOrBuilder extends
    */
   com.google.protobuf.ByteString
       getErrorsBytes(int index);
+
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  java.util.List<java.lang.String>
+      getWarningsList();
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  int getWarningsCount();
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  java.lang.String getWarnings(int index);
+  /**
+   * <code>repeated string warnings = 5;</code>
+   */
+  com.google.protobuf.ByteString
+      getWarningsBytes(int index);
+
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  java.util.List<java.lang.String>
+      getInfosList();
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  int getInfosCount();
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  java.lang.String getInfos(int index);
+  /**
+   * <code>repeated string infos = 6;</code>
+   */
+  com.google.protobuf.ByteString
+      getInfosBytes(int index);
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Reporter.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Reporter.java
@@ -10,6 +10,7 @@ public  final class Reporter extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Reporter)
     ReporterOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Reporter.newBuilder() to construct.
   private Reporter(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -22,14 +23,19 @@ public  final class Reporter extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Reporter(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -39,7 +45,8 @@ public  final class Reporter extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -69,6 +76,7 @@ public  final class Reporter extends
       if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
         tags_ = java.util.Collections.unmodifiableList(tags_);
       }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -88,7 +96,7 @@ public  final class Reporter extends
   public static final int REPORTER_ID_FIELD_NUMBER = 1;
   private long reporterId_;
   /**
-   * <code>optional uint64 reporter_id = 1;</code>
+   * <code>uint64 reporter_id = 1;</code>
    */
   public long getReporterId() {
     return reporterId_;
@@ -147,6 +155,7 @@ public  final class Reporter extends
     for (int i = 0; i < tags_.size(); i++) {
       output.writeMessage(4, tags_.get(i));
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -162,11 +171,11 @@ public  final class Reporter extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(4, tags_.get(i));
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -182,6 +191,7 @@ public  final class Reporter extends
         == other.getReporterId());
     result = result && getTagsList()
         .equals(other.getTagsList());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -191,7 +201,7 @@ public  final class Reporter extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + REPORTER_ID_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
         getReporterId());
@@ -204,6 +214,17 @@ public  final class Reporter extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Reporter parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Reporter parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Reporter parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -370,7 +391,7 @@ public  final class Reporter extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -383,12 +404,12 @@ public  final class Reporter extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -431,6 +452,7 @@ public  final class Reporter extends
           }
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -460,13 +482,13 @@ public  final class Reporter extends
 
     private long reporterId_ ;
     /**
-     * <code>optional uint64 reporter_id = 1;</code>
+     * <code>uint64 reporter_id = 1;</code>
      */
     public long getReporterId() {
       return reporterId_;
     }
     /**
-     * <code>optional uint64 reporter_id = 1;</code>
+     * <code>uint64 reporter_id = 1;</code>
      */
     public Builder setReporterId(long value) {
       
@@ -475,7 +497,7 @@ public  final class Reporter extends
       return this;
     }
     /**
-     * <code>optional uint64 reporter_id = 1;</code>
+     * <code>uint64 reporter_id = 1;</code>
      */
     public Builder clearReporterId() {
       
@@ -725,12 +747,12 @@ public  final class Reporter extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -753,7 +775,7 @@ public  final class Reporter extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Reporter(input, extensionRegistry);
+      return new Reporter(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReporterOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReporterOrBuilder.java
@@ -8,7 +8,7 @@ public interface ReporterOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional uint64 reporter_id = 1;</code>
+   * <code>uint64 reporter_id = 1;</code>
    */
   long getReporterId();
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Span.java
@@ -10,6 +10,7 @@ public  final class Span extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.Span)
     SpanOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use Span.newBuilder() to construct.
   private Span(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -25,14 +26,19 @@ public  final class Span extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private Span(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -42,7 +48,8 @@ public  final class Span extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -128,6 +135,7 @@ public  final class Span extends
       if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
         logs_ = java.util.Collections.unmodifiableList(logs_);
       }
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -147,19 +155,19 @@ public  final class Span extends
   public static final int SPAN_CONTEXT_FIELD_NUMBER = 1;
   private com.lightstep.tracer.grpc.SpanContext spanContext_;
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   public boolean hasSpanContext() {
     return spanContext_ != null;
   }
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   public com.lightstep.tracer.grpc.SpanContext getSpanContext() {
     return spanContext_ == null ? com.lightstep.tracer.grpc.SpanContext.getDefaultInstance() : spanContext_;
   }
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   public com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder() {
     return getSpanContext();
@@ -168,7 +176,7 @@ public  final class Span extends
   public static final int OPERATION_NAME_FIELD_NUMBER = 2;
   private volatile java.lang.Object operationName_;
   /**
-   * <code>optional string operation_name = 2;</code>
+   * <code>string operation_name = 2;</code>
    */
   public java.lang.String getOperationName() {
     java.lang.Object ref = operationName_;
@@ -183,7 +191,7 @@ public  final class Span extends
     }
   }
   /**
-   * <code>optional string operation_name = 2;</code>
+   * <code>string operation_name = 2;</code>
    */
   public com.google.protobuf.ByteString
       getOperationNameBytes() {
@@ -237,19 +245,19 @@ public  final class Span extends
   public static final int START_TIMESTAMP_FIELD_NUMBER = 4;
   private com.google.protobuf.Timestamp startTimestamp_;
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   public boolean hasStartTimestamp() {
     return startTimestamp_ != null;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   public com.google.protobuf.Timestamp getStartTimestamp() {
     return startTimestamp_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : startTimestamp_;
   }
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   public com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder() {
     return getStartTimestamp();
@@ -258,7 +266,7 @@ public  final class Span extends
   public static final int DURATION_MICROS_FIELD_NUMBER = 5;
   private long durationMicros_;
   /**
-   * <code>optional uint64 duration_micros = 5;</code>
+   * <code>uint64 duration_micros = 5;</code>
    */
   public long getDurationMicros() {
     return durationMicros_;
@@ -367,6 +375,7 @@ public  final class Span extends
     for (int i = 0; i < logs_.size(); i++) {
       output.writeMessage(7, logs_.get(i));
     }
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -401,11 +410,11 @@ public  final class Span extends
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(7, logs_.get(i));
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -437,6 +446,7 @@ public  final class Span extends
         .equals(other.getTagsList());
     result = result && getLogsList()
         .equals(other.getLogsList());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -446,7 +456,7 @@ public  final class Span extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     if (hasSpanContext()) {
       hash = (37 * hash) + SPAN_CONTEXT_FIELD_NUMBER;
       hash = (53 * hash) + getSpanContext().hashCode();
@@ -477,6 +487,17 @@ public  final class Span extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.Span parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.Span parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.Span parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -700,7 +721,7 @@ public  final class Span extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -713,12 +734,12 @@ public  final class Span extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -823,6 +844,7 @@ public  final class Span extends
           }
         }
       }
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -854,13 +876,13 @@ public  final class Span extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.SpanContext, com.lightstep.tracer.grpc.SpanContext.Builder, com.lightstep.tracer.grpc.SpanContextOrBuilder> spanContextBuilder_;
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public boolean hasSpanContext() {
       return spanContextBuilder_ != null || spanContext_ != null;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public com.lightstep.tracer.grpc.SpanContext getSpanContext() {
       if (spanContextBuilder_ == null) {
@@ -870,7 +892,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public Builder setSpanContext(com.lightstep.tracer.grpc.SpanContext value) {
       if (spanContextBuilder_ == null) {
@@ -886,7 +908,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public Builder setSpanContext(
         com.lightstep.tracer.grpc.SpanContext.Builder builderForValue) {
@@ -900,7 +922,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public Builder mergeSpanContext(com.lightstep.tracer.grpc.SpanContext value) {
       if (spanContextBuilder_ == null) {
@@ -918,7 +940,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public Builder clearSpanContext() {
       if (spanContextBuilder_ == null) {
@@ -932,7 +954,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public com.lightstep.tracer.grpc.SpanContext.Builder getSpanContextBuilder() {
       
@@ -940,7 +962,7 @@ public  final class Span extends
       return getSpanContextFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     public com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder() {
       if (spanContextBuilder_ != null) {
@@ -951,7 +973,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+     * <code>.lightstep.collector.SpanContext span_context = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.lightstep.tracer.grpc.SpanContext, com.lightstep.tracer.grpc.SpanContext.Builder, com.lightstep.tracer.grpc.SpanContextOrBuilder> 
@@ -969,7 +991,7 @@ public  final class Span extends
 
     private java.lang.Object operationName_ = "";
     /**
-     * <code>optional string operation_name = 2;</code>
+     * <code>string operation_name = 2;</code>
      */
     public java.lang.String getOperationName() {
       java.lang.Object ref = operationName_;
@@ -984,7 +1006,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional string operation_name = 2;</code>
+     * <code>string operation_name = 2;</code>
      */
     public com.google.protobuf.ByteString
         getOperationNameBytes() {
@@ -1000,7 +1022,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional string operation_name = 2;</code>
+     * <code>string operation_name = 2;</code>
      */
     public Builder setOperationName(
         java.lang.String value) {
@@ -1013,7 +1035,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional string operation_name = 2;</code>
+     * <code>string operation_name = 2;</code>
      */
     public Builder clearOperationName() {
       
@@ -1022,7 +1044,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional string operation_name = 2;</code>
+     * <code>string operation_name = 2;</code>
      */
     public Builder setOperationNameBytes(
         com.google.protobuf.ByteString value) {
@@ -1280,13 +1302,13 @@ public  final class Span extends
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> startTimestampBuilder_;
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public boolean hasStartTimestamp() {
       return startTimestampBuilder_ != null || startTimestamp_ != null;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public com.google.protobuf.Timestamp getStartTimestamp() {
       if (startTimestampBuilder_ == null) {
@@ -1296,7 +1318,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public Builder setStartTimestamp(com.google.protobuf.Timestamp value) {
       if (startTimestampBuilder_ == null) {
@@ -1312,7 +1334,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public Builder setStartTimestamp(
         com.google.protobuf.Timestamp.Builder builderForValue) {
@@ -1326,7 +1348,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public Builder mergeStartTimestamp(com.google.protobuf.Timestamp value) {
       if (startTimestampBuilder_ == null) {
@@ -1344,7 +1366,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public Builder clearStartTimestamp() {
       if (startTimestampBuilder_ == null) {
@@ -1358,7 +1380,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public com.google.protobuf.Timestamp.Builder getStartTimestampBuilder() {
       
@@ -1366,7 +1388,7 @@ public  final class Span extends
       return getStartTimestampFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     public com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder() {
       if (startTimestampBuilder_ != null) {
@@ -1377,7 +1399,7 @@ public  final class Span extends
       }
     }
     /**
-     * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+     * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
@@ -1395,13 +1417,13 @@ public  final class Span extends
 
     private long durationMicros_ ;
     /**
-     * <code>optional uint64 duration_micros = 5;</code>
+     * <code>uint64 duration_micros = 5;</code>
      */
     public long getDurationMicros() {
       return durationMicros_;
     }
     /**
-     * <code>optional uint64 duration_micros = 5;</code>
+     * <code>uint64 duration_micros = 5;</code>
      */
     public Builder setDurationMicros(long value) {
       
@@ -1410,7 +1432,7 @@ public  final class Span extends
       return this;
     }
     /**
-     * <code>optional uint64 duration_micros = 5;</code>
+     * <code>uint64 duration_micros = 5;</code>
      */
     public Builder clearDurationMicros() {
       
@@ -1900,12 +1922,12 @@ public  final class Span extends
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -1928,7 +1950,7 @@ public  final class Span extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Span(input, extensionRegistry);
+      return new Span(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/SpanContext.java
@@ -10,6 +10,7 @@ public  final class SpanContext extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:lightstep.collector.SpanContext)
     SpanContextOrBuilder {
+private static final long serialVersionUID = 0L;
   // Use SpanContext.newBuilder() to construct.
   private SpanContext(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
@@ -22,14 +23,19 @@ public  final class SpanContext extends
   @java.lang.Override
   public final com.google.protobuf.UnknownFieldSet
   getUnknownFields() {
-    return com.google.protobuf.UnknownFieldSet.getDefaultInstance();
+    return this.unknownFields;
   }
   private SpanContext(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    if (extensionRegistry == null) {
+      throw new java.lang.NullPointerException();
+    }
     int mutable_bitField0_ = 0;
+    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
       boolean done = false;
       while (!done) {
@@ -39,7 +45,8 @@ public  final class SpanContext extends
             done = true;
             break;
           default: {
-            if (!input.skipField(tag)) {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
             break;
@@ -75,6 +82,7 @@ public  final class SpanContext extends
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
@@ -105,7 +113,7 @@ public  final class SpanContext extends
   public static final int TRACE_ID_FIELD_NUMBER = 1;
   private long traceId_;
   /**
-   * <code>optional uint64 trace_id = 1;</code>
+   * <code>uint64 trace_id = 1;</code>
    */
   public long getTraceId() {
     return traceId_;
@@ -114,7 +122,7 @@ public  final class SpanContext extends
   public static final int SPAN_ID_FIELD_NUMBER = 2;
   private long spanId_;
   /**
-   * <code>optional uint64 span_id = 2;</code>
+   * <code>uint64 span_id = 2;</code>
    */
   public long getSpanId() {
     return spanId_;
@@ -220,6 +228,7 @@ public  final class SpanContext extends
         internalGetBaggage(),
         BaggageDefaultEntryHolder.defaultEntry,
         3);
+    unknownFields.writeTo(output);
   }
 
   public int getSerializedSize() {
@@ -245,11 +254,11 @@ public  final class SpanContext extends
       size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, baggage__);
     }
+    size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
   }
 
-  private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
@@ -267,6 +276,7 @@ public  final class SpanContext extends
         == other.getSpanId());
     result = result && internalGetBaggage().equals(
         other.internalGetBaggage());
+    result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
 
@@ -276,7 +286,7 @@ public  final class SpanContext extends
       return memoizedHashCode;
     }
     int hash = 41;
-    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + TRACE_ID_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
         getTraceId());
@@ -292,6 +302,17 @@ public  final class SpanContext extends
     return hash;
   }
 
+  public static com.lightstep.tracer.grpc.SpanContext parseFrom(
+      java.nio.ByteBuffer data)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data);
+  }
+  public static com.lightstep.tracer.grpc.SpanContext parseFrom(
+      java.nio.ByteBuffer data,
+      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws com.google.protobuf.InvalidProtocolBufferException {
+    return PARSER.parseFrom(data, extensionRegistry);
+  }
   public static com.lightstep.tracer.grpc.SpanContext parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -470,7 +491,7 @@ public  final class SpanContext extends
     }
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
     public Builder clearField(
@@ -483,12 +504,12 @@ public  final class SpanContext extends
     }
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, Object value) {
+        int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
-        Object value) {
+        java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
     public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -510,6 +531,7 @@ public  final class SpanContext extends
       }
       internalGetMutableBaggage().mergeFrom(
           other.internalGetBaggage());
+      this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
@@ -539,13 +561,13 @@ public  final class SpanContext extends
 
     private long traceId_ ;
     /**
-     * <code>optional uint64 trace_id = 1;</code>
+     * <code>uint64 trace_id = 1;</code>
      */
     public long getTraceId() {
       return traceId_;
     }
     /**
-     * <code>optional uint64 trace_id = 1;</code>
+     * <code>uint64 trace_id = 1;</code>
      */
     public Builder setTraceId(long value) {
       
@@ -554,7 +576,7 @@ public  final class SpanContext extends
       return this;
     }
     /**
-     * <code>optional uint64 trace_id = 1;</code>
+     * <code>uint64 trace_id = 1;</code>
      */
     public Builder clearTraceId() {
       
@@ -565,13 +587,13 @@ public  final class SpanContext extends
 
     private long spanId_ ;
     /**
-     * <code>optional uint64 span_id = 2;</code>
+     * <code>uint64 span_id = 2;</code>
      */
     public long getSpanId() {
       return spanId_;
     }
     /**
-     * <code>optional uint64 span_id = 2;</code>
+     * <code>uint64 span_id = 2;</code>
      */
     public Builder setSpanId(long value) {
       
@@ -580,7 +602,7 @@ public  final class SpanContext extends
       return this;
     }
     /**
-     * <code>optional uint64 span_id = 2;</code>
+     * <code>uint64 span_id = 2;</code>
      */
     public Builder clearSpanId() {
       
@@ -666,7 +688,8 @@ public  final class SpanContext extends
     }
 
     public Builder clearBaggage() {
-      getMutableBaggage().clear();
+      internalGetMutableBaggage().getMutableMap()
+          .clear();
       return this;
     }
     /**
@@ -676,7 +699,8 @@ public  final class SpanContext extends
     public Builder removeBaggage(
         java.lang.String key) {
       if (key == null) { throw new java.lang.NullPointerException(); }
-      getMutableBaggage().remove(key);
+      internalGetMutableBaggage().getMutableMap()
+          .remove(key);
       return this;
     }
     /**
@@ -695,7 +719,8 @@ public  final class SpanContext extends
         java.lang.String value) {
       if (key == null) { throw new java.lang.NullPointerException(); }
       if (value == null) { throw new java.lang.NullPointerException(); }
-      getMutableBaggage().put(key, value);
+      internalGetMutableBaggage().getMutableMap()
+          .put(key, value);
       return this;
     }
     /**
@@ -704,17 +729,18 @@ public  final class SpanContext extends
 
     public Builder putAllBaggage(
         java.util.Map<java.lang.String, java.lang.String> values) {
-      getMutableBaggage().putAll(values);
+      internalGetMutableBaggage().getMutableMap()
+          .putAll(values);
       return this;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.setUnknownFieldsProto3(unknownFields);
     }
 
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
-      return this;
+      return super.mergeUnknownFields(unknownFields);
     }
 
 
@@ -737,7 +763,7 @@ public  final class SpanContext extends
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SpanContext(input, extensionRegistry);
+      return new SpanContext(input, extensionRegistry);
     }
   };
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/SpanContextOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/SpanContextOrBuilder.java
@@ -8,12 +8,12 @@ public interface SpanContextOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional uint64 trace_id = 1;</code>
+   * <code>uint64 trace_id = 1;</code>
    */
   long getTraceId();
 
   /**
-   * <code>optional uint64 span_id = 2;</code>
+   * <code>uint64 span_id = 2;</code>
    */
   long getSpanId();
 

--- a/common/src/main/java/com/lightstep/tracer/grpc/SpanOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/SpanOrBuilder.java
@@ -8,24 +8,24 @@ public interface SpanOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   boolean hasSpanContext();
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   com.lightstep.tracer.grpc.SpanContext getSpanContext();
   /**
-   * <code>optional .lightstep.collector.SpanContext span_context = 1;</code>
+   * <code>.lightstep.collector.SpanContext span_context = 1;</code>
    */
   com.lightstep.tracer.grpc.SpanContextOrBuilder getSpanContextOrBuilder();
 
   /**
-   * <code>optional string operation_name = 2;</code>
+   * <code>string operation_name = 2;</code>
    */
   java.lang.String getOperationName();
   /**
-   * <code>optional string operation_name = 2;</code>
+   * <code>string operation_name = 2;</code>
    */
   com.google.protobuf.ByteString
       getOperationNameBytes();
@@ -55,20 +55,20 @@ public interface SpanOrBuilder extends
       int index);
 
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   boolean hasStartTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   com.google.protobuf.Timestamp getStartTimestamp();
   /**
-   * <code>optional .google.protobuf.Timestamp start_timestamp = 4;</code>
+   * <code>.google.protobuf.Timestamp start_timestamp = 4;</code>
    */
   com.google.protobuf.TimestampOrBuilder getStartTimestampOrBuilder();
 
   /**
-   * <code>optional uint64 duration_micros = 5;</code>
+   * <code>uint64 duration_micros = 5;</code>
    */
   long getDurationMicros();
 

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -491,9 +491,12 @@ public abstract class AbstractTracer implements Tracer {
         if (response.hasReceiveTimestamp() && response.hasTransmitTimestamp()) {
             long deltaMicros = (System.nanoTime() - originRelativeNanos) / 1000;
             long destinationMicros = originMicros + deltaMicros;
-            clockState.addSample(originMicros,
-                Util.protoTimeToEpochMicros(response.getReceiveTimestamp()),
-                Util.protoTimeToEpochMicros(response.getTransmitTimestamp()), destinationMicros);
+            clockState.addSample(
+                    originMicros,
+                    Util.protoTimeToEpochMicros(response.getReceiveTimestamp()),
+                    Util.protoTimeToEpochMicros(response.getTransmitTimestamp()),
+                    destinationMicros
+            );
         } else {
             warn("Collector response did not include timing info");
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -464,7 +464,7 @@ public abstract class AbstractTracer implements Tracer {
                 .setReporter(reporter)
                 .setAuth(auth)
                 .addAllSpans(spans)
-                .setTimestampOffsetMicros(Util.safeLongToInt(clockState.offsetMicros()))
+                .setTimestampOffsetMicros(clockState.offsetMicros())
                 .setInternalMetrics(clientMetrics.toInternalMetricsAndReset())
                 .build();
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -139,7 +139,7 @@ public class Span implements io.opentracing.Span {
             } else {
                 outKV.setJsonValue(Span.stringToJSONValue(inValue.toString()));
             }
-            log.addKeyvalues(outKV.build());
+            log.addFields(outKV.build());
         }
 
         synchronized (mutex) {

--- a/common/src/main/java/com/lightstep/tracer/shared/Util.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Util.java
@@ -42,13 +42,6 @@ class Util {
         return builder.build();
     }
 
-    static int safeLongToInt(long l) throws IllegalArgumentException {
-        if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException(l + " cannot be cast to an int without changing its value.");
-        }
-        return (int) l;
-    }
-
     static long nowMicrosApproximate() {
         return System.currentTimeMillis() * 1000;
     }

--- a/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
@@ -175,7 +175,7 @@ public class SpanTest {
 
     private Map<String, String> getLogFieldMap(Log rec) {
         Map<String, String> rval = new HashMap<>();
-        for (KeyValue kv : rec.getKeyvaluesList()) {
+        for (KeyValue kv : rec.getFieldsList()) {
             rval.put(kv.getKey(), kv.getStringValue());
         }
         return rval;


### PR DESCRIPTION
R: @danielamiao @jmacd 
CC: @frenchfrywpepper @thomashchan1 

This change both re-compiles the protos with the latest version of the proto definitions, and also removes conversion from long to int when setting TimestampOffsetMicros