### PR TITLE
remove annotation from comment so javadoc will not try and find it

### DIFF
--- a/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
@@ -8,12 +8,8 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
- TODO this was removed because it was making it difficult to compile the android tracer.
+ TODO generated annotation was removed because it was making it difficult to compile the android tracer.
  Someone with a greater knowledge of java compilation would likely be able to get the android tracer to compile.
-@javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.1.1)",
-    comments = "Source: collector.proto"
-)
  */
 public class CollectorServiceGrpc {
 


### PR DESCRIPTION
The javadoc code is still trying to resolve the annotation even in a comment so I am removing it entirely.