### PR TITLE
LS-4972: Expose deadlineMillis in OptionsBuilder

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -313,6 +313,14 @@ public final class Options {
             return this;
         }
 
+        /**
+         * Overrides the default deadlineMillis with the provided value.
+         */
+        public OptionsBuilder withDeadlineMillis(long deadlineMillis) {
+            this.deadlineMillis = deadlineMillis;
+            return this;
+        }
+
 	@SuppressWarnings("SameParameterValue")
     public OptionsBuilder withClockSkewCorrection(boolean clockCorrection) {
 	    this.useClockCorrection = clockCorrection;

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -29,6 +29,7 @@ public class OptionsTest {
     private static final String TAG_KEY = "my-tag-key";
     private static final String TAG_VALUE = "my-tag-value";
     private static final long GUID_VALUE = 123;
+    private static final long DEADLINE_MILLIS = 150;
 
     /**
      * Basic test of OptionsBuilder that ensures if I set everything explicitly, that these values
@@ -157,6 +158,7 @@ public class OptionsTest {
                 .withMaxBufferedSpans(MAX_BUFFERED_SPANS)
                 .withTag(TAG_KEY, TAG_VALUE)
                 .withTag(GUID_KEY, GUID_VALUE)
+                .withDeadlineMillis(DEADLINE_MILLIS)
                 .build();
     }
 
@@ -175,5 +177,6 @@ public class OptionsTest {
         assertEquals(MAX_BUFFERED_SPANS, options.maxBufferedSpans);
         assertEquals(TAG_VALUE, options.tags.get(TAG_KEY));
         assertEquals(GUID_VALUE, options.getGuid());
+        assertEquals(DEADLINE_MILLIS, options.deadlineMillis);
     }
 }


### PR DESCRIPTION
The default deadlineMillis is 30seconds, now customers can customize this value.