### PR TITLE
Add B3 Propagation Support

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -361,8 +361,9 @@ public abstract class AbstractTracer implements Tracer {
                     Propagator<C> propagator = (Propagator<C>) propagatorMap.get(format);
                     propagator.inject(lightstepSpanContext, carrier);
                 } catch (RuntimeException e) {
-                    error("Error while using custom propagator for injection. " +
-                                  "Format: " + format.toString(), e);
+                    warn("Error while using custom propagator for injection. " +
+                                  "Carrier type: " + carrier.getClass());
+                    error(e.getMessage(), e);
                 }
             } else {
                 info("Unsupported carrier type: " + carrier.getClass());
@@ -385,8 +386,9 @@ public abstract class AbstractTracer implements Tracer {
                     Propagator<C> propagator = (Propagator<C>) propagatorMap.get(format);
                     return propagator.extract(carrier);
                 } catch (RuntimeException e) {
-                    error("Error while using custom propagator for extraction. " +
-                                  "Format: " + format.toString(), e);
+                    warn("Error while using custom propagator for extraction. " +
+                                  "Carrier type: " + carrier.getClass());
+                    error(e.getMessage(), e);
                 }
             } else {
                 info("Unsupported carrier type: " + carrier.getClass());

--- a/common/src/main/java/com/lightstep/tracer/shared/B3Propagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/B3Propagator.java
@@ -1,0 +1,50 @@
+package com.lightstep.tracer.shared;
+
+import io.opentracing.propagation.TextMap;
+import java.util.Map;
+
+public class B3Propagator implements Propagator<TextMap> {
+
+    private static final String TRACE_ID_NAME = "X-B3-TraceId";
+    private static final String SPAN_ID_NAME = "X-B3-SpanId";
+    private static final String SAMPLED_NAME = "X-B3-Sampled";
+
+    private final TextMapPropagator textMapPropagator = new TextMapPropagator();
+
+    @Override
+    public void inject(SpanContext spanContext, TextMap carrier) {
+        long traceId = spanContext.getTraceId();
+        long spanId = spanContext.getSpanId();
+
+        carrier.put(TRACE_ID_NAME, Util.toHexString(traceId));
+        carrier.put(SPAN_ID_NAME, Util.toHexString(spanId));
+        carrier.put(SAMPLED_NAME, "true");
+
+        // Default to use TextMap propagation in case we could not find TraceId
+        if (0L == traceId) {
+            textMapPropagator.inject(spanContext, carrier);
+        }
+    }
+
+    @Override
+    public SpanContext extract(TextMap carrier) {
+        Long traceId = null;
+        Long spanId = null;
+
+        for (Map.Entry<String, String> entry : carrier) {
+            if (entry.getKey().equalsIgnoreCase(TRACE_ID_NAME)) {
+                traceId = Util.fromHexString(entry.getValue());
+            } else if (entry.getKey().equalsIgnoreCase(SPAN_ID_NAME)) {
+                spanId = Util.fromHexString(entry.getValue());
+            }
+        }
+
+        if (null != traceId && null != spanId) {
+            return new SpanContext(traceId, spanId);
+        } else {
+            // Default to use TextMap propagation
+            return textMapPropagator.extract(carrier);
+        }
+    }
+}
+

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -2,6 +2,8 @@ package com.lightstep.tracer.shared;
 
 
 import io.opentracing.ScopeManager;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
 import io.opentracing.util.ThreadLocalScopeManager;
 
 import java.net.MalformedURLException;
@@ -110,6 +112,7 @@ public final class Options {
     final boolean resetClient;
     final boolean useClockCorrection;
     final ScopeManager scopeManager;
+    final Map<Format<?>, Propagator<?>> propagatorMap;
 
     /**
      * The maximum amount of time the tracer should wait for a response from the collector when sending a report.
@@ -127,7 +130,8 @@ public final class Options {
             Map<String, Object> tags,
             boolean useClockCorrection,
             ScopeManager scopeManager,
-            long deadlineMillis
+            long deadlineMillis,
+            Map<Format<?>, Propagator<?>> propagatorMap
     ) {
         this.accessToken = accessToken;
         this.collectorUrl = collectorUrl;
@@ -140,6 +144,7 @@ public final class Options {
         this.useClockCorrection = useClockCorrection;
         this.scopeManager = scopeManager;
         this.deadlineMillis = deadlineMillis;
+        this.propagatorMap = propagatorMap;
     }
 
     long getGuid() {
@@ -161,6 +166,7 @@ public final class Options {
         private Map<String, Object> tags = new HashMap<>();
         private ScopeManager scopeManager;
         private long deadlineMillis = -1;
+        private Map<Format<?>, Propagator<?>> propagatorMap = new HashMap<>();
 
         public OptionsBuilder() {
         }
@@ -179,6 +185,12 @@ public final class Options {
             this.scopeManager = options.scopeManager;
             this.useClockCorrection = options.useClockCorrection;
             this.deadlineMillis = options.deadlineMillis;
+            this.propagatorMap = options.propagatorMap;
+        }
+
+        public <T extends TextMap> OptionsBuilder withPropagation(Format<T> format, Propagator<T> propagator) {
+            this.propagatorMap.put(format, propagator);
+            return this;
         }
 
         /**
@@ -353,7 +365,8 @@ public final class Options {
                     tags,
                     useClockCorrection,
                     scopeManager,
-                    deadlineMillis
+                    deadlineMillis,
+                    propagatorMap
             );
         }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -2,6 +2,7 @@ package com.lightstep.tracer.shared;
 
 
 import io.opentracing.ScopeManager;
+import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.util.ThreadLocalScopeManager;
@@ -188,7 +189,18 @@ public final class Options {
             this.propagatorMap = options.propagatorMap;
         }
 
-        public <T extends TextMap> OptionsBuilder withPropagation(Format<T> format, Propagator<T> propagator) {
+        /**
+         * Adds user defined {@link Propagator} to be used during
+         * {@link io.opentracing.Tracer#inject} and {@link io.opentracing.Tracer#extract} for
+         * the given type. If multiple propagators are used for the same Format,
+         * the propagator used with last invocation of this method will be used for
+         * that format.
+         * @param format Instance of {@link Format} for which custom Propagator will be used.
+         * @param propagator Instance of {@link Propagator} to be used
+         * @param <T> Type extending {@link TextMap}
+         */
+        public <T extends TextMap> OptionsBuilder withPropagation(
+                Format<T> format, Propagator<T> propagator) {
             this.propagatorMap.put(format, propagator);
             return this;
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
@@ -1,11 +1,9 @@
 package com.lightstep.tracer.shared;
 
-import java.math.BigInteger;
+import io.opentracing.propagation.TextMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import io.opentracing.propagation.TextMap;
 
 class TextMapPropagator implements Propagator<TextMap> {
     private static final Locale english = new Locale("en", "US");

--- a/common/src/test/java/com/lightstep/tracer/shared/B3PropagatorTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/B3PropagatorTest.java
@@ -1,0 +1,54 @@
+package com.lightstep.tracer.shared;
+
+import static org.junit.Assert.*;
+
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+
+public class B3PropagatorTest {
+
+    @Test
+    public void testExtract_mixedCaseIsLowered() {
+        Map<String, String> mixedCaseHeaders = new HashMap<>();
+
+        mixedCaseHeaders.put("X-B3-SpanId", Long.toHexString(1));
+        mixedCaseHeaders.put("X-b3-traceId", Long.toHexString(2));
+        mixedCaseHeaders.put("x-B3-sampled", "true");
+
+        B3Propagator subject = new B3Propagator();
+
+        SpanContext span = subject.extract(new TextMapExtractAdapter(mixedCaseHeaders));
+
+        assertNotNull(span);
+        assertEquals(span.getSpanId(), 1);
+        assertEquals(span.getTraceId(), 2);
+    }
+
+    @Test
+    public void testInjectAndExtractIds() {
+        B3Propagator undertest = new B3Propagator();
+        TextMap carrier = new TextMap() {
+            final Map<String, String> textMap = new HashMap<>();
+
+            public void put(String key, String value) {
+                textMap.put(key, value);
+            }
+
+            public Iterator<Entry<String, String>> iterator() {
+                return textMap.entrySet().iterator();
+            }
+        };
+        SpanContext spanContext = new SpanContext();
+        undertest.inject(spanContext, carrier);
+
+        SpanContext result = undertest.extract(carrier);
+
+        assertEquals(spanContext.getTraceId(), result.getTraceId());
+        assertEquals(spanContext.getSpanId(), result.getSpanId());
+    }
+}

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -1,7 +1,5 @@
 package com.lightstep.tracer.shared;
 
-import org.junit.Test;
-
 import static com.lightstep.tracer.shared.Options.COLLECTOR_PATH;
 import static com.lightstep.tracer.shared.Options.COMPONENT_NAME_KEY;
 import static com.lightstep.tracer.shared.Options.DEFAULT_PLAINTEXT_PORT;
@@ -19,6 +17,10 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import io.opentracing.propagation.Format.Builtin;
+import io.opentracing.propagation.TextMap;
+import org.junit.Test;
+
 public class OptionsTest {
     private static final String ACCESS_TOKEN = "my-access-token";
     private static final String COLLECTOR_HOST = "my-collector-host";
@@ -30,6 +32,7 @@ public class OptionsTest {
     private static final String TAG_VALUE = "my-tag-value";
     private static final long GUID_VALUE = 123;
     private static final long DEADLINE_MILLIS = 150;
+    private static final Propagator<TextMap> CUSTOM_PROPAGATOR = new B3Propagator();
 
     /**
      * Basic test of OptionsBuilder that ensures if I set everything explicitly, that these values
@@ -159,6 +162,7 @@ public class OptionsTest {
                 .withTag(TAG_KEY, TAG_VALUE)
                 .withTag(GUID_KEY, GUID_VALUE)
                 .withDeadlineMillis(DEADLINE_MILLIS)
+                .withPropagation(Builtin.TEXT_MAP, CUSTOM_PROPAGATOR)
                 .build();
     }
 
@@ -178,5 +182,7 @@ public class OptionsTest {
         assertEquals(TAG_VALUE, options.tags.get(TAG_KEY));
         assertEquals(GUID_VALUE, options.getGuid());
         assertEquals(DEADLINE_MILLIS, options.deadlineMillis);
+        assertFalse(options.propagatorMap.keySet().isEmpty());
+        assertEquals(CUSTOM_PROPAGATOR, options.propagatorMap.get(Builtin.TEXT_MAP));
     }
 }


### PR DESCRIPTION
This PR adds B3 header propagation as defined in https://github.com/openzipkin/b3-propagation.

- Added ability for users to add custom Propagators to LS tracer through options.
- Provided pre-made `B3Propagator` which falls back to `TextMapPropagator` in case it cannot inject/extract.
- Added unit test cases.

TODO: Currently there are three predefined propagators and the code tries each one of them in order. That should be changed to pre-initialize `propagationMap` and simply lookup based off `Format` rather than iterating through them.