### PR TITLE
Replace googleapis-common-protos with grpc-google-common-protos

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <io.opentracing.version>0.31.0</io.opentracing.version>
         <com.google.protobuf.version>3.5.1</com.google.protobuf.version>
-        <com.google.api.version>0.0.3</com.google.api.version>
+        <com.google.api.version>1.12.0</com.google.api.version>
     </properties>
 
     <build>
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.api.grpc</groupId>
-            <artifactId>googleapis-common-protos</artifactId>
+            <artifactId>grpc-google-common-protos</artifactId>
             <version>${com.google.api.version}</version>
         </dependency>
 


### PR DESCRIPTION
This PR replaces `googleapis-common-protos` artifact with `grpc-google-common-protos`.

`googleapis-common-protos` seems to be abandoned in favor of `grpc-google-common-protos`.

The latest version of `googleapis-common-protos` is 0.0.3 and it is 2-year-old ([released on August 4, 2016](https://mvnrepository.com/artifact/com.google.api.grpc/googleapis-common-protos)). It also contains a dependency on 2-year-old `com.google.protobuf:protobuf-java-util:jar:3.0.0-beta-3` which is found to be vulnerable by our SonarQube:

> Filename: protobuf-java-util-3.0.0-beta-3.jar | Reference: CVE-2015-5237 | CVSS Score: 6.5 | Category: CWE-119 Improper Restriction of Operations within the Bounds of a Memory Buffer | protobuf allows remote authenticated attackers to cause a heap-based buffer overflow.

`com.google.api.grpc:grpc-google-common-protos:jar:1.12.0` is the latest stable version [released on June 29, 2018](https://mvnrepository.com/artifact/com.google.api.grpc/grpc-google-common-protos).

---

**Dependency tree comparison**

This PR:

```
com.lightstep.tracer:example:jar:0.15.7
+- com.lightstep.tracer:java-common:jar:0.15.7:compile
|  +- io.opentracing:opentracing-api:jar:0.31.0:compile
|  +- io.opentracing:opentracing-util:jar:0.31.0:compile
|  |  \- io.opentracing:opentracing-noop:jar:0.31.0:compile
|  +- com.google.protobuf:protobuf-java:jar:3.5.1:compile
|  \- com.google.api.grpc:grpc-google-common-protos:jar:1.12.0:compile
|     +- io.grpc:grpc-stub:jar:1.10.1:compile
|     |  \- io.grpc:grpc-core:jar:1.10.1:compile
|     |     +- io.grpc:grpc-context:jar:1.10.1:compile
|     |     +- com.google.code.gson:gson:jar:2.7:compile
|     |     +- com.google.errorprone:error_prone_annotations:jar:2.1.2:compile
|     |     +- com.google.code.findbugs:jsr305:jar:3.0.0:compile
|     |     +- io.opencensus:opencensus-api:jar:0.11.0:compile
|     |     \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.11.0:compile
|     +- io.grpc:grpc-protobuf:jar:1.10.1:compile
|     |  +- com.google.guava:guava:jar:19.0:compile
|     |  +- com.google.protobuf:protobuf-java-util:jar:3.5.1:compile
|     |  \- io.grpc:grpc-protobuf-lite:jar:1.10.1:compile
|     \- com.google.api.grpc:proto-google-common-protos:jar:1.12.0:compile
\- com.lightstep.tracer:tracer-okhttp:jar:0.15.7:compile
   \- com.squareup.okhttp3:okhttp:jar:3.10.0:compile
      \- com.squareup.okio:okio:jar:1.14.0:compile
```

0.15.6:

```
--- maven-dependency-plugin:2.8:tree (default-cli) @ example ---
com.lightstep.tracer:example:jar:0.15.6
+- com.lightstep.tracer:java-common:jar:0.15.6:compile
|  +- io.opentracing:opentracing-api:jar:0.31.0:compile
|  +- io.opentracing:opentracing-util:jar:0.31.0:compile
|  |  \- io.opentracing:opentracing-noop:jar:0.31.0:compile
|  +- com.google.protobuf:protobuf-java:jar:3.5.1:compile
|  \- com.google.api.grpc:googleapis-common-protos:jar:0.0.3:compile
|     +- io.grpc:grpc-stub:jar:0.15.0:compile
|     |  \- io.grpc:grpc-core:jar:0.15.0:compile
|     |     \- com.google.code.findbugs:jsr305:jar:3.0.0:compile
|     \- io.grpc:grpc-protobuf:jar:0.15.0:compile
|        +- com.google.guava:guava:jar:19.0:compile
|        +- io.grpc:grpc-protobuf-lite:jar:0.15.0:compile
|        \- com.google.protobuf:protobuf-java-util:jar:3.0.0-beta-3:compile
|           \- com.google.code.gson:gson:jar:2.3:compile
\- com.lightstep.tracer:tracer-okhttp:jar:0.15.6:compile
   \- com.squareup.okhttp3:okhttp:jar:3.10.0:compile
      \- com.squareup.okio:okio:jar:1.14.0:compile
```

(generated with `mvn dependency:tree`)
