### PR TITLE
Do propagate parent SpanContext baggage to their children.

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanBuilder.java
@@ -152,6 +152,7 @@ public class SpanBuilder implements Tracer.SpanBuilder {
         grpcSpan.setStartTimestamp(Util.epochTimeMicrosToProtoTime(startTimestampMicros));
 
         Long traceId = this.traceId;
+        Map<String, String> baggage = null;
 
         if(parent == null && !ignoringActiveSpan) {
             parent = activeSpanContext();
@@ -160,15 +161,9 @@ public class SpanBuilder implements Tracer.SpanBuilder {
 
         if (parent != null) {
             traceId = parent.getTraceId();
+            baggage = new HashMap<String, String>(parent.getBaggage());
         }
-        SpanContext newSpanContext;
-        if (traceId != null && spanId != null) {
-            newSpanContext = new SpanContext(traceId, spanId);
-        } else if (traceId != null) {
-            newSpanContext = new SpanContext(traceId);
-        } else {
-            newSpanContext = new SpanContext();
-        }
+        SpanContext newSpanContext = new SpanContext(traceId, spanId, baggage);
 
         // Set the SpanContext of the span
         grpcSpan.setSpanContext(newSpanContext.getInnerSpanCtx());

--- a/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -56,6 +56,10 @@ public class SpanContext implements io.opentracing.SpanContext {
         return this.baggage.get(key);
     }
 
+    Map<String, String> getBaggage() {
+        return baggage;
+    }
+
     SpanContext withBaggageItem(String key, String value) {
         // This is really a "set" not a "with" but keeping as is to preserve behavior.
         this.baggage.put(key, value);

--- a/common/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/SpanBuilderTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -71,6 +73,24 @@ public class SpanBuilderTest {
     public void testStart_asFollowsFromSpanContext() throws Exception {
         undertest.addReference(FOLLOWS_FROM, context);
         verifySettingsFromParent();
+    }
+
+    /**
+     * Confirms the inherited baggage of the Span when the builder is given a parent SpanContext.
+     */
+    @Test
+    public void testStart_ParentBaggage() {
+        SpanContext parentContext = new SpanContext(TRACE_ID, SPAN_ID, new HashMap<String, String>() {{
+            put("foo", "bar");
+        }});
+
+        undertest.asChildOf(parentContext);
+        Span result = (Span)undertest.start();
+        assertEquals("bar", result.context().getBaggageItem("foo"));
+
+        result.setBaggageItem("another", "item");
+        assertEquals("item", result.context().getBaggageItem("another"));
+        assertNull(parentContext.getBaggageItem("another"));
     }
 
     @Test


### PR DESCRIPTION
Upon `SpanBuilder` receiving a `SpanContext` with baggage items, these were not being properly propagated to the resulting `Span`. This fixes it.

Also simplifies a small block in `SpanBuilder`, where we were choosing a given constructor of `SpanContext` based on the available parameters - but the full constructor already handles the null values for all of them.