### PR TITLE
Use COMPONENT_NAME_KEY for default component name

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -442,7 +442,7 @@ public final class Options {
                     if (st.hasMoreTokens()) {
                         String name = st.nextToken();
                         withComponentName(name);
-                        tags.put(LEGACY_COMPONENT_NAME_KEY, name);
+                        tags.put(COMPONENT_NAME_KEY, name);
                     }
                 }
             }

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -132,9 +132,6 @@ public class OptionsTest {
         Options options = new Options.OptionsBuilder().build();
         Object componentName = options.tags.get(COMPONENT_NAME_KEY);
         assertNotNull(componentName);
-
-        Object legacyComponentName = options.tags.get(LEGACY_COMPONENT_NAME_KEY);
-        assertEquals(componentName, legacyComponentName);
     }
 
     @Test


### PR DESCRIPTION
An issue was reported by a customer that they weren't able to override the component on a span using `lightstep.component_name`. The issue would only occur when the tracer was built without using `withComponentName` since the default component name used the legacy key. Our backend does not support overriding components when the legacy key is used, so this PR moves away from the legacy key. 