### PR TITLE
Add withScopeManager to OptionBuilder

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -1,9 +1,7 @@
 package com.lightstep.tracer.shared;
 
 
-import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.util.ThreadLocalScopeManager;
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -289,8 +289,13 @@ public final class Options {
          * Sets scope manager attribute. If not set, will default to the ThreadLocalScopeManager
          *
          * @param scopeManager The scopeManager for the LightStep tracer.
+         * @throws IllegalArgumentException If the scopeManager is null.
          */
         public OptionsBuilder withScopeManager(ScopeManager scopeManager) {
+            if (scopeManager == null) {
+                throw new IllegalArgumentException("scopeManager cannot be null");
+            }
+
             this.scopeManager = scopeManager;
             return this;
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -1,6 +1,7 @@
 package com.lightstep.tracer.shared;
 
 
+import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
@@ -281,6 +282,16 @@ public final class Options {
                 throw new IllegalArgumentException("Invalid collector port: " + collectorPort);
             }
             this.collectorPort = collectorPort;
+            return this;
+        }
+
+        /**
+         * Sets scope manager attribute. If not set, will default to the ThreadLocalScopeManager
+         *
+         * @param scopeManager The scopeManager for the LightStep tracer.
+         */
+        public OptionsBuilder withScopeManager(ScopeManager scopeManager) {
+            this.scopeManager = scopeManager;
             return this;
         }
 

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import io.opentracing.ScopeManager;
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.util.ThreadLocalScopeManager;
@@ -114,7 +115,16 @@ public class OptionsTest {
         Options options = new Options.OptionsBuilder()
                 .build();
 
-        assertEquals(ThreadLocalScopeManager.class, options.scopeManager.getClass());
+        assertTrue(options.scopeManager instanceof ThreadLocalScopeManager);
+    }
+
+    @Test
+    public void testOptionsBuilder_withScopeManager() throws Exception {
+        Options options = new Options.OptionsBuilder()
+                .withScopeManager(io.opentracing.noop.NoopScopeManager.INSTANCE)
+                .build();
+
+        assertTrue(options.scopeManager instanceof io.opentracing.noop.NoopScopeManager);
     }
 
     @Test

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMap;
+import io.opentracing.util.ThreadLocalScopeManager;
 import org.junit.Test;
 
 public class OptionsTest {
@@ -93,6 +94,12 @@ public class OptionsTest {
                 .withPropagator(null, CUSTOM_PROPAGATOR);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testOptionsBuilder_nullScopeManager() {
+        new Options.OptionsBuilder()
+                .withScopeManager(null);
+    }
+
     @Test
     public void testOptionsBuilder_httpsNoPortProvided() throws Exception {
         Options options = new Options.OptionsBuilder()
@@ -100,6 +107,14 @@ public class OptionsTest {
                 .build();
 
         assertEquals(DEFAULT_SECURE_PORT, options.collectorUrl.getPort());
+    }
+
+    @Test
+    public void testOptionsBuilder_defaultScopeManager() throws Exception {
+        Options options = new Options.OptionsBuilder()
+                .build();
+
+        assertEquals(ThreadLocalScopeManager.class, options.scopeManager.getClass());
     }
 
     @Test
@@ -184,6 +199,7 @@ public class OptionsTest {
                 .withTag(GUID_KEY, GUID_VALUE)
                 .withDeadlineMillis(DEADLINE_MILLIS)
                 .withPropagator(Builtin.TEXT_MAP, CUSTOM_PROPAGATOR)
+                .withScopeManager(new ThreadLocalScopeManager())
                 .build();
     }
 


### PR DESCRIPTION
Warning: Java noob, my tests pass and I have also live tested this in a sample Java app. 

Addressing a customer request for the ability to modify the scope manager away from the default ThreadLocalScopeManager.