### PR TITLE
Push to a tracking branch when incrementing VERSION.

### DIFF
--- a/inc-version.sh
+++ b/inc-version.sh
@@ -5,6 +5,7 @@
 # make publish
 # which will call out to this script
 
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # Use maven-help-plugin to get the current project.version
 CURRENT_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
@@ -23,4 +24,4 @@ git add example/pom.xml
 git add pom.xml
 
 git commit -m "VERSION $NEW_VERSION"
-git push
+git push --set-upstream origin $CURRENT_BRANCH


### PR DESCRIPTION
Tiny tuning to the deployment process, when pushing a new VERSION, as quite often a brand new branch will include such changes (the current script expects the current branch is *already* a tracking one, else it will fail).

Useful in case a branch was created solely for incrementing the VERSION - and works just fine in case the current branch is already tracking one in origin.