### PR TITLE
Add a conformance module to build the related (fat) jar.

### DIFF
--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>java</artifactId>
+        <groupId>com.lightstep.tracer</groupId>
+        <version>0.15.8</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>conformance</artifactId>
+
+    <!-- Rely on okhttp, which is simpler than grpc, dependency wise -->
+    <dependencies>
+        <dependency>
+            <groupId>com.lightstep.tracer</groupId>
+            <artifactId>java-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lightstep.tracer</groupId>
+            <artifactId>tracer-okhttp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,4 +57,14 @@
         <module>common</module>
         <module>example</module>
     </modules>
+
+    <profiles>
+        <!-- Additional profile to include the fat conformance jar -->
+        <profile>
+            <id>conformance</id>
+            <modules>
+                <module>conformance</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Adds a profille/module to build a fat jar.

This can enabled/built with `mvn package -P conformance`, and it will create `conformance/target/conformance.jar` with the the dependencies (using the `okhttp` lib, as it's lighter in dependencies than `grpc`. Guess you don't need any of them really, but the base code requires at least of them to be present.

You can then call it with `java -cp conformance/target/conformance.jar com.lightstep.tracer.conformance.ConformanceRunner`