### PR TITLE
Add meta event support.

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/grpc/Auth.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Auth.java
@@ -43,17 +43,17 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
+          case 10: {
+            java.lang.String s = input.readStringRequireUtf8();
+
+            accessToken_ = s;
+            break;
+          }
           default: {
             if (!parseUnknownFieldProto3(
                 input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
-            break;
-          }
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            accessToken_ = s;
             break;
           }
         }
@@ -73,6 +73,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Auth_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Auth_fieldAccessorTable
@@ -115,6 +116,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -124,6 +126,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getAccessTokenBytes().isEmpty()) {
@@ -132,6 +135,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -246,6 +250,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -253,6 +258,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Auth prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -276,6 +282,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Auth_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Auth_fieldAccessorTable
@@ -298,6 +305,7 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       accessToken_ = "";
@@ -305,15 +313,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Auth_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Auth getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Auth.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Auth build() {
       com.lightstep.tracer.grpc.Auth result = buildPartial();
       if (!result.isInitialized()) {
@@ -322,6 +333,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Auth buildPartial() {
       com.lightstep.tracer.grpc.Auth result = new com.lightstep.tracer.grpc.Auth(this);
       result.accessToken_ = accessToken_;
@@ -329,32 +341,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Auth) {
         return mergeFrom((com.lightstep.tracer.grpc.Auth)other);
@@ -375,10 +394,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -465,11 +486,13 @@ private static final long serialVersionUID = 0L;
       onChanged();
       return this;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -491,6 +514,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Auth>
       PARSER = new com.google.protobuf.AbstractParser<Auth>() {
+    @java.lang.Override
     public Auth parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -508,6 +532,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Auth getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Collector.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Collector.java
@@ -130,18 +130,19 @@ public final class Collector {
       "2\031.lightstep.collector.Span\022\037\n\027timestamp" +
       "_offset_micros\030\005 \001(\003\022>\n\020internal_metrics" +
       "\030\006 \001(\0132$.lightstep.collector.InternalMet" +
-      "rics\"\032\n\007Command\022\017\n\007disable\030\001 \001(\010\"\340\001\n\016Rep" +
-      "ortResponse\022.\n\010commands\030\001 \003(\0132\034.lightste" +
-      "p.collector.Command\0225\n\021receive_timestamp" +
-      "\030\002 \001(\0132\032.google.protobuf.Timestamp\0226\n\022tr" +
-      "ansmit_timestamp\030\003 \001(\0132\032.google.protobuf" +
-      ".Timestamp\022\016\n\006errors\030\004 \003(\t\022\020\n\010warnings\030\005" +
-      " \003(\t\022\r\n\005infos\030\006 \003(\t2\225\001\n\020CollectorService" +
-      "\022\200\001\n\006Report\022\".lightstep.collector.Report" +
-      "Request\032#.lightstep.collector.ReportResp" +
-      "onse\"-\202\323\344\223\002\'\"\017/api/v2/reports:\001*Z\021\022\017/api" +
-      "/v2/reportsB1\n\031com.lightstep.tracer.grpc" +
-      "P\001Z\013collectorpb\242\002\004LSPBb\006proto3"
+      "rics\",\n\007Command\022\017\n\007disable\030\001 \001(\010\022\020\n\010dev_" +
+      "mode\030\002 \001(\010\"\340\001\n\016ReportResponse\022.\n\010command" +
+      "s\030\001 \003(\0132\034.lightstep.collector.Command\0225\n" +
+      "\021receive_timestamp\030\002 \001(\0132\032.google.protob" +
+      "uf.Timestamp\0226\n\022transmit_timestamp\030\003 \001(\013" +
+      "2\032.google.protobuf.Timestamp\022\016\n\006errors\030\004" +
+      " \003(\t\022\020\n\010warnings\030\005 \003(\t\022\r\n\005infos\030\006 \003(\t2\225\001" +
+      "\n\020CollectorService\022\200\001\n\006Report\022\".lightste" +
+      "p.collector.ReportRequest\032#.lightstep.co" +
+      "llector.ReportResponse\"-\202\323\344\223\002\'\"\017/api/v2/" +
+      "reports:\001*Z\021\022\017/api/v2/reportsB1\n\031com.lig" +
+      "htstep.tracer.grpcP\001Z\013collectorpb\242\002\004LSPB" +
+      "b\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -228,7 +229,7 @@ public final class Collector {
     internal_static_lightstep_collector_Command_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_lightstep_collector_Command_descriptor,
-        new java.lang.String[] { "Disable", });
+        new java.lang.String[] { "Disable", "DevMode", });
     internal_static_lightstep_collector_ReportResponse_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_lightstep_collector_ReportResponse_fieldAccessorTable = new

--- a/common/src/main/java/com/lightstep/tracer/grpc/Command.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Command.java
@@ -17,6 +17,7 @@ private static final long serialVersionUID = 0L;
   }
   private Command() {
     disable_ = false;
+    devMode_ = false;
   }
 
   @java.lang.Override
@@ -43,16 +44,21 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
+          case 8: {
+
+            disable_ = input.readBool();
+            break;
+          }
+          case 16: {
+
+            devMode_ = input.readBool();
+            break;
+          }
           default: {
             if (!parseUnknownFieldProto3(
                 input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
-            break;
-          }
-          case 8: {
-
-            disable_ = input.readBool();
             break;
           }
         }
@@ -72,6 +78,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Command_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Command_fieldAccessorTable
@@ -88,7 +95,17 @@ private static final long serialVersionUID = 0L;
     return disable_;
   }
 
+  public static final int DEV_MODE_FIELD_NUMBER = 2;
+  private boolean devMode_;
+  /**
+   * <code>bool dev_mode = 2;</code>
+   */
+  public boolean getDevMode() {
+    return devMode_;
+  }
+
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -98,14 +115,19 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (disable_ != false) {
       output.writeBool(1, disable_);
     }
+    if (devMode_ != false) {
+      output.writeBool(2, devMode_);
+    }
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -114,6 +136,10 @@ private static final long serialVersionUID = 0L;
     if (disable_ != false) {
       size += com.google.protobuf.CodedOutputStream
         .computeBoolSize(1, disable_);
+    }
+    if (devMode_ != false) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(2, devMode_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -133,6 +159,8 @@ private static final long serialVersionUID = 0L;
     boolean result = true;
     result = result && (getDisable()
         == other.getDisable());
+    result = result && (getDevMode()
+        == other.getDevMode());
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -147,6 +175,9 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + DISABLE_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
         getDisable());
+    hash = (37 * hash) + DEV_MODE_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+        getDevMode());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -222,6 +253,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -229,6 +261,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Command prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -252,6 +285,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Command_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Command_fieldAccessorTable
@@ -274,22 +308,28 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       disable_ = false;
 
+      devMode_ = false;
+
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Command_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Command getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Command.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Command build() {
       com.lightstep.tracer.grpc.Command result = buildPartial();
       if (!result.isInitialized()) {
@@ -298,39 +338,48 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Command buildPartial() {
       com.lightstep.tracer.grpc.Command result = new com.lightstep.tracer.grpc.Command(this);
       result.disable_ = disable_;
+      result.devMode_ = devMode_;
       onBuilt();
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Command) {
         return mergeFrom((com.lightstep.tracer.grpc.Command)other);
@@ -345,15 +394,20 @@ private static final long serialVersionUID = 0L;
       if (other.getDisable() != false) {
         setDisable(other.getDisable());
       }
+      if (other.getDevMode() != false) {
+        setDevMode(other.getDevMode());
+      }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -397,11 +451,39 @@ private static final long serialVersionUID = 0L;
       onChanged();
       return this;
     }
+
+    private boolean devMode_ ;
+    /**
+     * <code>bool dev_mode = 2;</code>
+     */
+    public boolean getDevMode() {
+      return devMode_;
+    }
+    /**
+     * <code>bool dev_mode = 2;</code>
+     */
+    public Builder setDevMode(boolean value) {
+      
+      devMode_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>bool dev_mode = 2;</code>
+     */
+    public Builder clearDevMode() {
+      
+      devMode_ = false;
+      onChanged();
+      return this;
+    }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -423,6 +505,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Command>
       PARSER = new com.google.protobuf.AbstractParser<Command>() {
+    @java.lang.Override
     public Command parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -440,6 +523,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Command getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/CommandOrBuilder.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/CommandOrBuilder.java
@@ -11,4 +11,9 @@ public interface CommandOrBuilder extends
    * <code>bool disable = 1;</code>
    */
   boolean getDisable();
+
+  /**
+   * <code>bool dev_mode = 2;</code>
+   */
+  boolean getDevMode();
 }

--- a/common/src/main/java/com/lightstep/tracer/grpc/InternalMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/InternalMetrics.java
@@ -46,13 +46,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             com.google.protobuf.Timestamp.Builder subBuilder = null;
             if (startTimestamp_ != null) {
@@ -98,6 +91,13 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(com.lightstep.tracer.grpc.MetricsSample.parser(), extensionRegistry));
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -124,6 +124,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_InternalMetrics_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_InternalMetrics_fieldAccessorTable
@@ -268,6 +269,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -277,6 +279,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (startTimestamp_ != null) {
@@ -297,6 +300,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -456,6 +460,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -463,6 +468,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.InternalMetrics prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -486,6 +492,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_InternalMetrics_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_InternalMetrics_fieldAccessorTable
@@ -511,6 +518,7 @@ private static final long serialVersionUID = 0L;
         getGaugesFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       if (startTimestampBuilder_ == null) {
@@ -542,15 +550,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_InternalMetrics_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.InternalMetrics getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.InternalMetrics.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.InternalMetrics build() {
       com.lightstep.tracer.grpc.InternalMetrics result = buildPartial();
       if (!result.isInitialized()) {
@@ -559,6 +570,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.InternalMetrics buildPartial() {
       com.lightstep.tracer.grpc.InternalMetrics result = new com.lightstep.tracer.grpc.InternalMetrics(this);
       int from_bitField0_ = bitField0_;
@@ -601,32 +613,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.InternalMetrics) {
         return mergeFrom((com.lightstep.tracer.grpc.InternalMetrics)other);
@@ -727,10 +746,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1612,11 +1633,13 @@ private static final long serialVersionUID = 0L;
       }
       return gaugesBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -1638,6 +1661,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<InternalMetrics>
       PARSER = new com.google.protobuf.AbstractParser<InternalMetrics>() {
+    @java.lang.Override
     public InternalMetrics parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1655,6 +1679,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.InternalMetrics getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/KeyValue.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/KeyValue.java
@@ -47,13 +47,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             java.lang.String s = input.readStringRequireUtf8();
 
@@ -87,6 +80,13 @@ private static final long serialVersionUID = 0L;
             value_ = s;
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -104,6 +104,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_KeyValue_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_KeyValue_fieldAccessorTable
@@ -329,6 +330,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -338,6 +340,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getKeyBytes().isEmpty()) {
@@ -364,6 +367,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -555,6 +559,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -562,6 +567,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.KeyValue prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -589,6 +595,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_KeyValue_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_KeyValue_fieldAccessorTable
@@ -611,6 +618,7 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       key_ = "";
@@ -620,15 +628,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_KeyValue_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.KeyValue getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.KeyValue.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.KeyValue build() {
       com.lightstep.tracer.grpc.KeyValue result = buildPartial();
       if (!result.isInitialized()) {
@@ -637,6 +648,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.KeyValue buildPartial() {
       com.lightstep.tracer.grpc.KeyValue result = new com.lightstep.tracer.grpc.KeyValue(this);
       result.key_ = key_;
@@ -660,32 +672,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.KeyValue) {
         return mergeFrom((com.lightstep.tracer.grpc.KeyValue)other);
@@ -735,10 +754,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1140,11 +1161,13 @@ private static final long serialVersionUID = 0L;
       onChanged();
       return this;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -1166,6 +1189,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<KeyValue>
       PARSER = new com.google.protobuf.AbstractParser<KeyValue>() {
+    @java.lang.Override
     public KeyValue parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1183,6 +1207,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.KeyValue getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Log.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Log.java
@@ -43,13 +43,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             com.google.protobuf.Timestamp.Builder subBuilder = null;
             if (timestamp_ != null) {
@@ -72,6 +65,13 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(com.lightstep.tracer.grpc.KeyValue.parser(), extensionRegistry));
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -92,6 +92,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Log_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Log_fieldAccessorTable
@@ -157,6 +158,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -166,6 +168,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (timestamp_ != null) {
@@ -177,6 +180,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -307,6 +311,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -314,6 +319,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Log prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -337,6 +343,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Log_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Log_fieldAccessorTable
@@ -360,6 +367,7 @@ private static final long serialVersionUID = 0L;
         getFieldsFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       if (timestampBuilder_ == null) {
@@ -377,15 +385,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Log_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Log getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Log.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Log build() {
       com.lightstep.tracer.grpc.Log result = buildPartial();
       if (!result.isInitialized()) {
@@ -394,6 +405,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Log buildPartial() {
       com.lightstep.tracer.grpc.Log result = new com.lightstep.tracer.grpc.Log(this);
       int from_bitField0_ = bitField0_;
@@ -417,32 +429,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Log) {
         return mergeFrom((com.lightstep.tracer.grpc.Log)other);
@@ -488,10 +507,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -867,11 +888,13 @@ private static final long serialVersionUID = 0L;
       }
       return fieldsBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -893,6 +916,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Log>
       PARSER = new com.google.protobuf.AbstractParser<Log>() {
+    @java.lang.Override
     public Log parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -910,6 +934,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Log getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/MetricsSample.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/MetricsSample.java
@@ -43,13 +43,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             java.lang.String s = input.readStringRequireUtf8();
 
@@ -64,6 +57,13 @@ private static final long serialVersionUID = 0L;
           case 25: {
             valueCase_ = 3;
             value_ = input.readDouble();
+            break;
+          }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
             break;
           }
         }
@@ -83,6 +83,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_MetricsSample_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_MetricsSample_fieldAccessorTable
@@ -185,6 +186,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -194,6 +196,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
@@ -210,6 +213,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -365,6 +369,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -372,6 +377,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.MetricsSample prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -395,6 +401,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_MetricsSample_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_MetricsSample_fieldAccessorTable
@@ -417,6 +424,7 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       name_ = "";
@@ -426,15 +434,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_MetricsSample_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.MetricsSample getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.MetricsSample.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.MetricsSample build() {
       com.lightstep.tracer.grpc.MetricsSample result = buildPartial();
       if (!result.isInitialized()) {
@@ -443,6 +454,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.MetricsSample buildPartial() {
       com.lightstep.tracer.grpc.MetricsSample result = new com.lightstep.tracer.grpc.MetricsSample(this);
       result.name_ = name_;
@@ -457,32 +469,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.MetricsSample) {
         return mergeFrom((com.lightstep.tracer.grpc.MetricsSample)other);
@@ -516,10 +535,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -681,11 +702,13 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -707,6 +730,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<MetricsSample>
       PARSER = new com.google.protobuf.AbstractParser<MetricsSample>() {
+    @java.lang.Override
     public MetricsSample parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -724,6 +748,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.MetricsSample getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Reference.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Reference.java
@@ -43,13 +43,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 8: {
             int rawValue = input.readEnum();
 
@@ -69,6 +62,13 @@ private static final long serialVersionUID = 0L;
 
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -86,6 +86,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reference_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reference_fieldAccessorTable
@@ -203,6 +204,7 @@ private static final long serialVersionUID = 0L;
    * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
    */
   public com.lightstep.tracer.grpc.Reference.Relationship getRelationship() {
+    @SuppressWarnings("deprecation")
     com.lightstep.tracer.grpc.Reference.Relationship result = com.lightstep.tracer.grpc.Reference.Relationship.valueOf(relationship_);
     return result == null ? com.lightstep.tracer.grpc.Reference.Relationship.UNRECOGNIZED : result;
   }
@@ -229,6 +231,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -238,6 +241,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (relationship_ != com.lightstep.tracer.grpc.Reference.Relationship.CHILD_OF.getNumber()) {
@@ -249,6 +253,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -376,6 +381,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -383,6 +389,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Reference prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -406,6 +413,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reference_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reference_fieldAccessorTable
@@ -428,6 +436,7 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       relationship_ = 0;
@@ -441,15 +450,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reference_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reference getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Reference.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reference build() {
       com.lightstep.tracer.grpc.Reference result = buildPartial();
       if (!result.isInitialized()) {
@@ -458,6 +470,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reference buildPartial() {
       com.lightstep.tracer.grpc.Reference result = new com.lightstep.tracer.grpc.Reference(this);
       result.relationship_ = relationship_;
@@ -470,32 +483,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Reference) {
         return mergeFrom((com.lightstep.tracer.grpc.Reference)other);
@@ -518,10 +538,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -559,6 +581,7 @@ private static final long serialVersionUID = 0L;
      * <code>.lightstep.collector.Reference.Relationship relationship = 1;</code>
      */
     public com.lightstep.tracer.grpc.Reference.Relationship getRelationship() {
+      @SuppressWarnings("deprecation")
       com.lightstep.tracer.grpc.Reference.Relationship result = com.lightstep.tracer.grpc.Reference.Relationship.valueOf(relationship_);
       return result == null ? com.lightstep.tracer.grpc.Reference.Relationship.UNRECOGNIZED : result;
     }
@@ -700,11 +723,13 @@ private static final long serialVersionUID = 0L;
       }
       return spanContextBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -726,6 +751,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Reference>
       PARSER = new com.google.protobuf.AbstractParser<Reference>() {
+    @java.lang.Override
     public Reference parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -743,6 +769,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Reference getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportRequest.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportRequest.java
@@ -44,13 +44,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             com.lightstep.tracer.grpc.Reporter.Builder subBuilder = null;
             if (reporter_ != null) {
@@ -104,6 +97,13 @@ private static final long serialVersionUID = 0L;
 
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -124,6 +124,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportRequest_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportRequest_fieldAccessorTable
@@ -240,6 +241,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -249,6 +251,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (reporter_ != null) {
@@ -269,6 +272,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -434,6 +438,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -441,6 +446,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.ReportRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -464,6 +470,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportRequest_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportRequest_fieldAccessorTable
@@ -487,6 +494,7 @@ private static final long serialVersionUID = 0L;
         getSpansFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       if (reporterBuilder_ == null) {
@@ -518,15 +526,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportRequest_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportRequest getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.ReportRequest.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportRequest build() {
       com.lightstep.tracer.grpc.ReportRequest result = buildPartial();
       if (!result.isInitialized()) {
@@ -535,6 +546,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportRequest buildPartial() {
       com.lightstep.tracer.grpc.ReportRequest result = new com.lightstep.tracer.grpc.ReportRequest(this);
       int from_bitField0_ = bitField0_;
@@ -569,32 +581,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.ReportRequest) {
         return mergeFrom((com.lightstep.tracer.grpc.ReportRequest)other);
@@ -649,10 +668,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1288,11 +1309,13 @@ private static final long serialVersionUID = 0L;
       }
       return internalMetricsBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -1314,6 +1337,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<ReportRequest>
       PARSER = new com.google.protobuf.AbstractParser<ReportRequest>() {
+    @java.lang.Override
     public ReportRequest parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1331,6 +1355,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.ReportRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/ReportResponse.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/ReportResponse.java
@@ -46,13 +46,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
               commands_ = new java.util.ArrayList<com.lightstep.tracer.grpc.Command>();
@@ -115,6 +108,13 @@ private static final long serialVersionUID = 0L;
             infos_.add(s);
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -144,6 +144,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportResponse_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportResponse_fieldAccessorTable
@@ -317,6 +318,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -326,6 +328,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     for (int i = 0; i < commands_.size(); i++) {
@@ -349,6 +352,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -534,6 +538,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -541,6 +546,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.ReportResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -564,6 +570,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportResponse_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportResponse_fieldAccessorTable
@@ -587,6 +594,7 @@ private static final long serialVersionUID = 0L;
         getCommandsFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       if (commandsBuilder_ == null) {
@@ -616,15 +624,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_ReportResponse_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportResponse getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.ReportResponse.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportResponse build() {
       com.lightstep.tracer.grpc.ReportResponse result = buildPartial();
       if (!result.isInitialized()) {
@@ -633,6 +644,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.ReportResponse buildPartial() {
       com.lightstep.tracer.grpc.ReportResponse result = new com.lightstep.tracer.grpc.ReportResponse(this);
       int from_bitField0_ = bitField0_;
@@ -676,32 +688,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.ReportResponse) {
         return mergeFrom((com.lightstep.tracer.grpc.ReportResponse)other);
@@ -780,10 +799,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1558,11 +1579,13 @@ private static final long serialVersionUID = 0L;
       onChanged();
       return this;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -1584,6 +1607,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<ReportResponse>
       PARSER = new com.google.protobuf.AbstractParser<ReportResponse>() {
+    @java.lang.Override
     public ReportResponse parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1601,6 +1625,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.ReportResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Reporter.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Reporter.java
@@ -44,13 +44,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 8: {
 
             reporterId_ = input.readUInt64();
@@ -63,6 +56,13 @@ private static final long serialVersionUID = 0L;
             }
             tags_.add(
                 input.readMessage(com.lightstep.tracer.grpc.KeyValue.parser(), extensionRegistry));
+            break;
+          }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
             break;
           }
         }
@@ -85,6 +85,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reporter_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reporter_fieldAccessorTable
@@ -138,6 +139,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -147,6 +149,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (reporterId_ != 0L) {
@@ -158,6 +161,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -284,6 +288,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -291,6 +296,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Reporter prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -314,6 +320,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reporter_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reporter_fieldAccessorTable
@@ -337,6 +344,7 @@ private static final long serialVersionUID = 0L;
         getTagsFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       reporterId_ = 0L;
@@ -350,15 +358,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Reporter_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reporter getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Reporter.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reporter build() {
       com.lightstep.tracer.grpc.Reporter result = buildPartial();
       if (!result.isInitialized()) {
@@ -367,6 +378,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Reporter buildPartial() {
       com.lightstep.tracer.grpc.Reporter result = new com.lightstep.tracer.grpc.Reporter(this);
       int from_bitField0_ = bitField0_;
@@ -386,32 +398,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Reporter) {
         return mergeFrom((com.lightstep.tracer.grpc.Reporter)other);
@@ -457,10 +476,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -745,11 +766,13 @@ private static final long serialVersionUID = 0L;
       }
       return tagsBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -771,6 +794,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Reporter>
       PARSER = new com.google.protobuf.AbstractParser<Reporter>() {
+    @java.lang.Override
     public Reporter parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -788,6 +812,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Reporter getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/Span.java
@@ -47,13 +47,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 10: {
             com.lightstep.tracer.grpc.SpanContext.Builder subBuilder = null;
             if (spanContext_ != null) {
@@ -118,6 +111,13 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(com.lightstep.tracer.grpc.Log.parser(), extensionRegistry));
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -144,6 +144,7 @@ private static final long serialVersionUID = 0L;
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Span_descriptor;
   }
 
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Span_fieldAccessorTable
@@ -343,6 +344,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -352,6 +354,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (spanContext_ != null) {
@@ -378,6 +381,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -557,6 +561,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -564,6 +569,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.Span prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -587,6 +593,7 @@ private static final long serialVersionUID = 0L;
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Span_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Span_fieldAccessorTable
@@ -612,6 +619,7 @@ private static final long serialVersionUID = 0L;
         getLogsFieldBuilder();
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       if (spanContextBuilder_ == null) {
@@ -651,15 +659,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_Span_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Span getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.Span.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Span build() {
       com.lightstep.tracer.grpc.Span result = buildPartial();
       if (!result.isInitialized()) {
@@ -668,6 +679,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.Span buildPartial() {
       com.lightstep.tracer.grpc.Span result = new com.lightstep.tracer.grpc.Span(this);
       int from_bitField0_ = bitField0_;
@@ -716,32 +728,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.Span) {
         return mergeFrom((com.lightstep.tracer.grpc.Span)other);
@@ -849,10 +868,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1920,11 +1941,13 @@ private static final long serialVersionUID = 0L;
       }
       return logsBuilder_;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -1946,6 +1969,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<Span>
       PARSER = new com.google.protobuf.AbstractParser<Span>() {
+    @java.lang.Override
     public Span parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1963,6 +1987,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.Span getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/grpc/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/grpc/SpanContext.java
@@ -44,13 +44,6 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownFieldProto3(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
           case 8: {
 
             traceId_ = input.readUInt64();
@@ -74,6 +67,13 @@ private static final long serialVersionUID = 0L;
                 baggage__.getKey(), baggage__.getValue());
             break;
           }
+          default: {
+            if (!parseUnknownFieldProto3(
+                input, unknownFields, extensionRegistry, tag)) {
+              done = true;
+            }
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -92,6 +92,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @SuppressWarnings({"rawtypes"})
+  @java.lang.Override
   protected com.google.protobuf.MapField internalGetMapField(
       int number) {
     switch (number) {
@@ -102,6 +103,7 @@ private static final long serialVersionUID = 0L;
             "Invalid map field number: " + number);
     }
   }
+  @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_SpanContext_fieldAccessorTable
@@ -205,6 +207,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+  @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
     if (isInitialized == 1) return true;
@@ -214,6 +217,7 @@ private static final long serialVersionUID = 0L;
     return true;
   }
 
+  @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (traceId_ != 0L) {
@@ -231,6 +235,7 @@ private static final long serialVersionUID = 0L;
     unknownFields.writeTo(output);
   }
 
+  @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
     if (size != -1) return size;
@@ -372,6 +377,7 @@ private static final long serialVersionUID = 0L;
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
+  @java.lang.Override
   public Builder newBuilderForType() { return newBuilder(); }
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
@@ -379,6 +385,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder(com.lightstep.tracer.grpc.SpanContext prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+  @java.lang.Override
   public Builder toBuilder() {
     return this == DEFAULT_INSTANCE
         ? new Builder() : new Builder().mergeFrom(this);
@@ -424,6 +431,7 @@ private static final long serialVersionUID = 0L;
               "Invalid map field number: " + number);
       }
     }
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_SpanContext_fieldAccessorTable
@@ -446,6 +454,7 @@ private static final long serialVersionUID = 0L;
               .alwaysUseFieldBuilders) {
       }
     }
+    @java.lang.Override
     public Builder clear() {
       super.clear();
       traceId_ = 0L;
@@ -456,15 +465,18 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
       return com.lightstep.tracer.grpc.Collector.internal_static_lightstep_collector_SpanContext_descriptor;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.SpanContext getDefaultInstanceForType() {
       return com.lightstep.tracer.grpc.SpanContext.getDefaultInstance();
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.SpanContext build() {
       com.lightstep.tracer.grpc.SpanContext result = buildPartial();
       if (!result.isInitialized()) {
@@ -473,6 +485,7 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public com.lightstep.tracer.grpc.SpanContext buildPartial() {
       com.lightstep.tracer.grpc.SpanContext result = new com.lightstep.tracer.grpc.SpanContext(this);
       int from_bitField0_ = bitField0_;
@@ -486,32 +499,39 @@ private static final long serialVersionUID = 0L;
       return result;
     }
 
+    @java.lang.Override
     public Builder clone() {
       return (Builder) super.clone();
     }
+    @java.lang.Override
     public Builder setField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.setField(field, value);
     }
+    @java.lang.Override
     public Builder clearField(
         com.google.protobuf.Descriptors.FieldDescriptor field) {
       return (Builder) super.clearField(field);
     }
+    @java.lang.Override
     public Builder clearOneof(
         com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return (Builder) super.clearOneof(oneof);
     }
+    @java.lang.Override
     public Builder setRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         int index, java.lang.Object value) {
       return (Builder) super.setRepeatedField(field, index, value);
     }
+    @java.lang.Override
     public Builder addRepeatedField(
         com.google.protobuf.Descriptors.FieldDescriptor field,
         java.lang.Object value) {
       return (Builder) super.addRepeatedField(field, value);
     }
+    @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.lightstep.tracer.grpc.SpanContext) {
         return mergeFrom((com.lightstep.tracer.grpc.SpanContext)other);
@@ -536,10 +556,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    @java.lang.Override
     public final boolean isInitialized() {
       return true;
     }
 
+    @java.lang.Override
     public Builder mergeFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -733,11 +755,13 @@ private static final long serialVersionUID = 0L;
           .putAll(values);
       return this;
     }
+    @java.lang.Override
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFieldsProto3(unknownFields);
     }
 
+    @java.lang.Override
     public final Builder mergeUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -759,6 +783,7 @@ private static final long serialVersionUID = 0L;
 
   private static final com.google.protobuf.Parser<SpanContext>
       PARSER = new com.google.protobuf.AbstractParser<SpanContext>() {
+    @java.lang.Override
     public SpanContext parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -776,6 +801,7 @@ private static final long serialVersionUID = 0L;
     return PARSER;
   }
 
+  @java.lang.Override
   public com.lightstep.tracer.grpc.SpanContext getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -515,6 +515,15 @@ public abstract class AbstractTracer implements Tracer {
             return ReportResult.Error(spans.size());
         }
 
+        if (!response.getCommandsList().isEmpty()) {
+            List<Command> cmds = response.getCommandsList();
+            for (Command cmd : cmds) {
+                if (cmd.getDevMode()) {
+                    this.enableMetaReporting = true;
+                }
+            }
+        }
+
         if (response.hasReceiveTimestamp() && response.hasTransmitTimestamp()) {
             long deltaMicros = (System.nanoTime() - originRelativeNanos) / 1000;
             long destinationMicros = originMicros + deltaMicros;

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -196,10 +196,10 @@ public abstract class AbstractTracer implements Tracer {
             return;
         }
         if (!firstReportHasRun) {
-            buildSpan("lightstep.tracer_create")
+            buildSpan(LightStepConstants.MetaEvents.TracerCreateOperation)
                     .ignoreActiveSpan()
-                    .withTag("lightstep.meta_event", true)
-                    .withTag("lightstep.tracer_guid", reporter.getReporterId())
+                    .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
+                    .withTag(LightStepConstants.MetaEvents.TracerGuidKey, reporter.getReporterId())
                     .start()
                     .finish();
             firstReportHasRun = true;
@@ -361,12 +361,12 @@ public abstract class AbstractTracer implements Tracer {
         }
         SpanContext lightstepSpanContext = (SpanContext) spanContext;
         if (enableMetaReporting) {
-            buildSpan("lightstep.inject_span")
+            buildSpan(LightStepConstants.MetaEvents.InjectOperation)
                     .ignoreActiveSpan()
-                    .withTag("lightstep.meta_event", true)
-                    .withTag("lightstep.span_id", lightstepSpanContext.getSpanId())
-                    .withTag("lightstep.trace_id", lightstepSpanContext.getTraceId())
-                    .withTag("lightstep.propagation_format", format.getClass().getName())
+                    .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
+                    .withTag(LightStepConstants.MetaEvents.SpanIdKey, lightstepSpanContext.getSpanId())
+                    .withTag(LightStepConstants.MetaEvents.TraceIdKey, lightstepSpanContext.getTraceId())
+                    .withTag(LightStepConstants.MetaEvents.PropagationFormatKey, format.getClass().getName())
                     .start()
                     .finish();
         }
@@ -385,10 +385,10 @@ public abstract class AbstractTracer implements Tracer {
             return null;
         }
         if (enableMetaReporting) {
-            buildSpan("lightstep.extract_span")
+            buildSpan(LightStepConstants.MetaEvents.ExtractOperation)
                     .ignoreActiveSpan()
-                    .withTag("lightstep.meta_event", true)
-                    .withTag("lightstep.propagation_format", format.getClass().getName())
+                    .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
+                    .withTag(LightStepConstants.MetaEvents.PropagationFormatKey, format.getClass().getName())
                     .start()
                     .finish();
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/LightStepConstants.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/LightStepConstants.java
@@ -1,0 +1,19 @@
+package com.lightstep.tracer.shared;
+
+public final class LightStepConstants {
+    private LightStepConstants() {}
+    public final class MetaEvents {
+        private MetaEvents() {}
+
+        public static final String MetaEventKey = "lightstep.meta_event";
+        public static final String PropagationFormatKey = "lightstep.propagation_format";
+        public static final String TraceIdKey = "lightstep.trace_id";
+        public static final String SpanIdKey = "lightstep.span_id";
+        public static final String TracerGuidKey = "lightstep.tracer_guid";
+        public static final String ExtractOperation = "lightstep.extract_span";
+        public static final String InjectOperation = "lightstep.inject_span";
+        public static final String SpanStartOperation = "lightstep.span_start";
+        public static final String SpanFinishOperation = "lightstep.span_finish";
+        public static final String TracerCreateOperation = "lightstep.tracer_create";
+    }
+}

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -111,6 +111,11 @@ public final class Options {
     @SuppressWarnings("WeakerAccess")
     public static final int VERBOSITY_NONE = 0;
 
+    /**
+     * Enable LightStep Meta Event Reporting
+     */
+    final boolean enableMetaEventLogging;
+
     final String accessToken;
     final URL collectorUrl;
     final Map<String, Object> tags;
@@ -155,6 +160,7 @@ public final class Options {
         this.scopeManager = scopeManager;
         this.deadlineMillis = deadlineMillis;
         this.propagators = propagators;
+        this.enableMetaEventLogging = false;
     }
 
     long getGuid() {
@@ -177,6 +183,7 @@ public final class Options {
         private ScopeManager scopeManager;
         private long deadlineMillis = -1;
         private Map<Format<?>, Propagator<?>> propagators = new HashMap<>();
+        private boolean enableMetaEventLogging = false;
 
         public OptionsBuilder() {
         }
@@ -196,6 +203,7 @@ public final class Options {
             this.useClockCorrection = options.useClockCorrection;
             this.deadlineMillis = options.deadlineMillis;
             this.propagators = options.propagators;
+            this.enableMetaEventLogging = options.enableMetaEventLogging;
         }
 
         /**
@@ -366,6 +374,16 @@ public final class Options {
          */
         public OptionsBuilder withDeadlineMillis(long deadlineMillis) {
             this.deadlineMillis = deadlineMillis;
+            return this;
+        }
+
+        /**
+         * Enables LightStep Meta Event Reporting
+         * @param enableMetaEvents
+         * @return
+         */
+        public OptionsBuilder withMetaEventLogging(boolean enableMetaEvents) {
+            this.enableMetaEventLogging = enableMetaEvents;
             return this;
         }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -25,7 +25,7 @@ public class Span implements io.opentracing.Span {
         this.grpcSpan = grpcSpan;
         this.startTimestampRelativeNanos = startTimestampRelativeNanos;
 
-        if (tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
+        if (tracer != null && tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
             tracer.buildSpan("lightstep.span_start")
                     .ignoreActiveSpan()
                     .withTag("lightstep.meta_event", true)

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -26,11 +26,11 @@ public class Span implements io.opentracing.Span {
         this.startTimestampRelativeNanos = startTimestampRelativeNanos;
 
         if (tracer != null && tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
-            tracer.buildSpan("lightstep.span_start")
+            tracer.buildSpan(LightStepConstants.MetaEvents.SpanStartOperation)
                     .ignoreActiveSpan()
-                    .withTag("lightstep.meta_event", true)
-                    .withTag("lightstep.span_id", context.getSpanId())
-                    .withTag("lightstep.trace_id", context.getTraceId())
+                    .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
+                    .withTag(LightStepConstants.MetaEvents.SpanIdKey, context.getSpanId())
+                    .withTag(LightStepConstants.MetaEvents.TraceIdKey, context.getTraceId())
                     .start()
                     .finish();
         }
@@ -49,11 +49,11 @@ public class Span implements io.opentracing.Span {
     @Override
     public void finish(long finishTimeMicros) {
         if (tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
-            tracer.buildSpan("lightstep.span_finish")
+            tracer.buildSpan(LightStepConstants.MetaEvents.SpanFinishOperation)
                     .ignoreActiveSpan()
-                    .withTag("lightstep.meta_event", true)
-                    .withTag("lightstep.span_id", context.getSpanId())
-                    .withTag("lightstep.trace_id", context.getTraceId())
+                    .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
+                    .withTag(LightStepConstants.MetaEvents.SpanIdKey, context.getSpanId())
+                    .withTag(LightStepConstants.MetaEvents.TraceIdKey, context.getTraceId())
                     .start()
                     .finish();
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/Util.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Util.java
@@ -56,6 +56,9 @@ class Util {
     }
 
     static boolean IsNotMetaSpan(Span span) {
+        if (span == null) {
+            return true;
+        }
         KeyValue kvp = KeyValue.newBuilder().setKey("lightstep.meta_event").setBoolValue(true).build();
         return !span.getGrpcSpan().getTagsList().contains(kvp);
     }

--- a/common/src/main/java/com/lightstep/tracer/shared/Util.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Util.java
@@ -1,6 +1,7 @@
 package com.lightstep.tracer.shared;
 
 import com.google.protobuf.Timestamp;
+import com.lightstep.tracer.grpc.KeyValue;
 
 import java.math.BigInteger;
 import java.util.Random;
@@ -52,5 +53,10 @@ class Util {
 
     static String toHexString(long l) {
         return Long.toHexString(l);
+    }
+
+    static boolean IsNotMetaSpan(Span span) {
+        KeyValue kvp = KeyValue.newBuilder().setKey("lightstep.meta_event").setBoolValue(true).build();
+        return !span.getGrpcSpan().getTagsList().contains(kvp);
     }
 }

--- a/common/src/main/java/com/lightstep/tracer/shared/Util.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Util.java
@@ -59,7 +59,7 @@ class Util {
         if (span == null) {
             return true;
         }
-        KeyValue kvp = KeyValue.newBuilder().setKey("lightstep.meta_event").setBoolValue(true).build();
+        KeyValue kvp = KeyValue.newBuilder().setKey(LightStepConstants.MetaEvents.MetaEventKey).setBoolValue(true).build();
         return !span.getGrpcSpan().getTagsList().contains(kvp);
     }
 }


### PR DESCRIPTION
This PR adds support for reporting 'meta events' - detailed lifecycle information about a tracer and its spans - to the Java tracer. It can be enabled via the `withMetaEventLogging` method in `OptionsBuilder`. This option is not suitable for production environments as it generates a significant amount of spans.