### PR TITLE
Do not send any meta Span on first run if meta events are disabled.

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -198,7 +198,7 @@ public abstract class AbstractTracer implements Tracer, Closeable {
         if (reportingThread != null) {
             return;
         }
-        if (!firstReportHasRun) {
+        if (enableMetaReporting && !firstReportHasRun) {
             buildSpan(LightStepConstants.MetaEvents.TracerCreateOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)


### PR DESCRIPTION
According to the C# implementation, we should send a meta `Span` on first run *only* if meta event reporting is also enabled: https://github.com/lightstep/lightstep-tracer-csharp/commit/7db7b8569dbde7afa21bb29f7376c15c9e81d531#diff-b408e98d2705e4616d4a5dc95be6e32bR123

This was causing some unexpected `Span` objects being created during tests for our `JRETracer` and got our tests failing there (and in some cases, even causing a `StackOverflowException`).

This needs to be merged prior to do actual `JRETracer` and Android releases.

@austinlparker I need your review here, to make sure this is a correct change.

(And we need a way to test some of our stuff without waiting on the implementations to run their own test).