### PR TITLE
Configure gRPC load balancing and resolution behavior

### DIFF
--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
@@ -2,6 +2,7 @@ package com.lightstep.tracer.shared;
 
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.util.RoundRobinLoadBalancerFactory;
 
 // public for reflective instantiation.
 public class GrpcCollectorClientProvider extends CollectorClientProvider {
@@ -27,10 +28,20 @@ public class GrpcCollectorClientProvider extends CollectorClientProvider {
             Options options
     ) {
         try {
-            ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
+            ManagedChannelBuilder<?> builder;
+            if (options.grpcCollectorTarget != null) {
+                builder = ManagedChannelBuilder.forTarget(options.grpcCollectorTarget);
+            } else {
+                builder = ManagedChannelBuilder.forAddress(
                     options.collectorUrl.getHost(),
                     options.collectorUrl.getPort()
-            );
+                );
+            }
+
+            if (options.grpcRoundRobin) {
+                builder.loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance());
+            }
+
             if (options.collectorUrl.getProtocol().equals("http")) {
                 builder.usePlaintext(true);
             }


### PR DESCRIPTION
When deploying the lightstep satellites as part of a headless k8s service the current behavior of this library is as follows:

1. resolve the A record using the operating system dns resolver.
2. pick the first satellite record returned and start sending it traces.
3. if `resetClient` is true - reset the client every 5 minutes and potentially pick a different satellite.
4. if the connection is reset because the k8s pod is torn down or restarted - go back to step 1.

This behavior is not ideal when sending a large amount of traces from many different backend services with a large pool of satellites. With autoscaling in k8s the satellites pools quickly become unbalanced with various different recall windows.

Instead we can instruct gRPC to round-robin between all the available satellites on a per request basis to spread out the requests more evenly.

We can also specify our own gRPC NameResolverProvider that can lookup satellites using your preferred service discovery system.

Currently gRPC java doesn’t provide a mechanism to  periodically refresh DNS records. Records are only refreshed if there is a connection issue.

Resources:
https://github.com/grpc/grpc-java/issues/1463
https://github.com/grpc/grpc-java/issues/2514