### PR TITLE
Add OptionsBuilder.disableMetaEventLogging()

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -120,8 +120,9 @@ public abstract class AbstractTracer implements Tracer, Closeable {
 
     private final Map<Format<?>, Propagator<?>> propagators;
 
-    private boolean firstReportHasRun;
-    public boolean enableMetaReporting;
+    boolean firstReportHasRun;
+    boolean disableMetaEventLogging;
+    boolean metaEventLoggingEnabled;
 
     public AbstractTracer(Options options) {
         scopeManager = options.scopeManager;
@@ -170,8 +171,10 @@ public abstract class AbstractTracer implements Tracer, Closeable {
         }
 
         propagators = options.propagators;
+
         firstReportHasRun = false;
-        enableMetaReporting = options.enableMetaEventLogging;
+        metaEventLoggingEnabled = false;
+        disableMetaEventLogging = options.disableMetaEventLogging;
     }
 
     /**
@@ -198,7 +201,7 @@ public abstract class AbstractTracer implements Tracer, Closeable {
         if (reportingThread != null) {
             return;
         }
-        if (enableMetaReporting && !firstReportHasRun) {
+        if (metaEventLoggingEnabled && !firstReportHasRun) {
             buildSpan(LightStepConstants.MetaEvents.TracerCreateOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
@@ -363,7 +366,7 @@ public abstract class AbstractTracer implements Tracer, Closeable {
             return;
         }
         SpanContext lightstepSpanContext = (SpanContext) spanContext;
-        if (enableMetaReporting) {
+        if (metaEventLoggingEnabled) {
             buildSpan(LightStepConstants.MetaEvents.InjectOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
@@ -387,7 +390,7 @@ public abstract class AbstractTracer implements Tracer, Closeable {
             info("Unsupported carrier type: " + carrier.getClass());
             return null;
         }
-        if (enableMetaReporting) {
+        if (metaEventLoggingEnabled) {
             buildSpan(LightStepConstants.MetaEvents.ExtractOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
@@ -537,15 +540,6 @@ public abstract class AbstractTracer implements Tracer, Closeable {
             return ReportResult.Error(spans.size());
         }
 
-        if (!response.getCommandsList().isEmpty()) {
-            List<Command> cmds = response.getCommandsList();
-            for (Command cmd : cmds) {
-                if (cmd.getDevMode()) {
-                    this.enableMetaReporting = true;
-                }
-            }
-        }
-
         if (response.hasReceiveTimestamp() && response.hasTransmitTimestamp()) {
             long deltaMicros = (System.nanoTime() - originRelativeNanos) / 1000;
             long destinationMicros = originMicros + deltaMicros;
@@ -564,6 +558,10 @@ public abstract class AbstractTracer implements Tracer, Closeable {
             for (Command command : response.getCommandsList()) {
                 if (command.getDisable()) {
                     disable();
+                } else if (command.getDevMode()) {
+                    if (!disableMetaEventLogging) {
+                        metaEventLoggingEnabled = true;
+                    }
                 }
             }
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -102,9 +102,10 @@ public final class Options {
     public static final int VERBOSITY_NONE = 0;
 
     /**
-     * Enable LightStep Meta Event Reporting
+     * Disable Meta Event Reporting
+     * even if a server command requested it.
      */
-    final boolean enableMetaEventLogging;
+    final boolean disableMetaEventLogging;
 
     final String accessToken;
     final URL collectorUrl;
@@ -140,7 +141,8 @@ public final class Options {
             long deadlineMillis,
             Map<Format<?>, Propagator<?>> propagators,
             String grpcCollectorTarget,
-            boolean grpcRoundRobin
+            boolean grpcRoundRobin,
+            boolean disableMetaEventLogging
     ) {
         this.accessToken = accessToken;
         this.collectorUrl = collectorUrl;
@@ -156,7 +158,7 @@ public final class Options {
         this.propagators = propagators;
         this.grpcCollectorTarget = grpcCollectorTarget;
         this.grpcRoundRobin = grpcRoundRobin;
-        this.enableMetaEventLogging = false;
+        this.disableMetaEventLogging = disableMetaEventLogging;
     }
 
     long getGuid() {
@@ -179,7 +181,7 @@ public final class Options {
         private ScopeManager scopeManager;
         private long deadlineMillis = -1;
         private Map<Format<?>, Propagator<?>> propagators = new HashMap<>();
-        private boolean enableMetaEventLogging = false;
+        private boolean disableMetaEventLogging = false;
         private String grpcCollectorTarget;
         private boolean grpcRoundRobin = false;
 
@@ -201,7 +203,7 @@ public final class Options {
             this.useClockCorrection = options.useClockCorrection;
             this.deadlineMillis = options.deadlineMillis;
             this.propagators = options.propagators;
-            this.enableMetaEventLogging = options.enableMetaEventLogging;
+            this.disableMetaEventLogging = options.disableMetaEventLogging;
             this.grpcCollectorTarget = options.grpcCollectorTarget;
             this.grpcRoundRobin = options.grpcRoundRobin;
         }
@@ -424,12 +426,12 @@ public final class Options {
         }
 
         /**
-         * Enables LightStep Meta Event Reporting
-         * @param enableMetaEvents
-         * @return
+         * Disables LightStep Meta Event Reporting
+         * even if a server command requested it.
+         * @param disableMetaEventLogging
          */
-        public OptionsBuilder withMetaEventLogging(boolean enableMetaEvents) {
-            this.enableMetaEventLogging = enableMetaEvents;
+        public OptionsBuilder withDisableMetaEventLogging(boolean disableMetaEventLogging) {
+            this.disableMetaEventLogging = disableMetaEventLogging;
             return this;
         }
 
@@ -469,7 +471,8 @@ public final class Options {
                     deadlineMillis,
                     propagators,
                     grpcCollectorTarget,
-                    grpcRoundRobin
+                    grpcRoundRobin,
+                    disableMetaEventLogging
             );
         }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -25,7 +25,7 @@ public class Span implements io.opentracing.Span {
         this.grpcSpan = grpcSpan;
         this.startTimestampRelativeNanos = startTimestampRelativeNanos;
 
-        if (tracer != null && tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
+        if (tracer != null && tracer.metaEventLoggingEnabled && Util.IsNotMetaSpan(this)) {
             tracer.buildSpan(LightStepConstants.MetaEvents.SpanStartOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)
@@ -48,7 +48,7 @@ public class Span implements io.opentracing.Span {
 
     @Override
     public void finish(long finishTimeMicros) {
-        if (tracer.enableMetaReporting && Util.IsNotMetaSpan(this)) {
+        if (tracer.metaEventLoggingEnabled && Util.IsNotMetaSpan(this)) {
             tracer.buildSpan(LightStepConstants.MetaEvents.SpanFinishOperation)
                     .ignoreActiveSpan()
                     .withTag(LightStepConstants.MetaEvents.MetaEventKey, true)

--- a/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/OptionsTest.java
@@ -207,6 +207,7 @@ public class OptionsTest {
                 .withDeadlineMillis(DEADLINE_MILLIS)
                 .withPropagator(Builtin.TEXT_MAP, CUSTOM_PROPAGATOR)
                 .withScopeManager(new ThreadLocalScopeManager())
+                .withDisableMetaEventLogging(true)
                 .build();
     }
 
@@ -228,5 +229,6 @@ public class OptionsTest {
         assertEquals(DEADLINE_MILLIS, options.deadlineMillis);
         assertFalse(options.propagators.keySet().isEmpty());
         assertEquals(CUSTOM_PROPAGATOR, options.propagators.get(Builtin.TEXT_MAP));
+        assertTrue(options.disableMetaEventLogging);
     }
 }


### PR DESCRIPTION
* Also, don't allow user to directly
  enable meta event logging.

(Also renamed the original field, in an attempt to hint the different purpose against the new `disableMetaEventLogging` field).