### PR TITLE
LS-8648 - Add Access Token as header to GRPC and HTTP Tracing Requests

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.17.1</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -39,10 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.16.2</version>
+        <version>0.16.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -40,6 +40,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0-M1</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.17.0</version>
+        <version>0.17.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.17.1</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.16.2</version>
+        <version>0.16.3</version>
     </parent>
 
     <artifactId>tracer-grpc</artifactId>
@@ -36,6 +36,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0-M1</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.17.1</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>tracer-grpc</artifactId>
@@ -35,10 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
@@ -1,15 +1,11 @@
 package com.lightstep.tracer.grpc;
 
-import io.grpc.Metadata;
-import io.grpc.ServerCall;
-
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
-import static io.grpc.Metadata.*;
 
 /**
  TODO generated annotation was removed because it was making it difficult to compile the android tracer.
@@ -21,7 +17,6 @@ public class CollectorServiceGrpc {
 
   public static final String SERVICE_NAME = "lightstep.collector.CollectorService";
 
-  public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("LightStep-Access-Token", ASCII_STRING_MARSHALLER);
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -103,8 +98,6 @@ public class CollectorServiceGrpc {
      */
     public void report(com.lightstep.tracer.grpc.ReportRequest request,
         io.grpc.stub.StreamObserver<com.lightstep.tracer.grpc.ReportResponse> responseObserver) {
-      Metadata headers = new Metadata();
-      headers.put(ACCESS_TOKEN_HEADER, request.getAuth().getAccessToken());
 
       asyncUnaryCall(
           getChannel().newCall(METHOD_REPORT, getCallOptions()), request, responseObserver);

--- a/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/CollectorServiceGrpc.java
@@ -1,11 +1,15 @@
 package com.lightstep.tracer.grpc;
 
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.Metadata.*;
 
 /**
  TODO generated annotation was removed because it was making it difficult to compile the android tracer.
@@ -16,6 +20,8 @@ public class CollectorServiceGrpc {
   private CollectorServiceGrpc() {}
 
   public static final String SERVICE_NAME = "lightstep.collector.CollectorService";
+
+  public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("LightStep-Access-Token", ASCII_STRING_MARSHALLER);
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -97,6 +103,9 @@ public class CollectorServiceGrpc {
      */
     public void report(com.lightstep.tracer.grpc.ReportRequest request,
         io.grpc.stub.StreamObserver<com.lightstep.tracer.grpc.ReportResponse> responseObserver) {
+      Metadata headers = new Metadata();
+      headers.put(ACCESS_TOKEN_HEADER, request.getAuth().getAccessToken());
+
       asyncUnaryCall(
           getChannel().newCall(METHOD_REPORT, getCallOptions()), request, responseObserver);
     }

--- a/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
@@ -1,0 +1,31 @@
+package com.lightstep.tracer.grpc;
+
+import io.grpc.*;
+import static io.grpc.Metadata.*;
+
+public class GrpcClientInterceptor implements ClientInterceptor {
+    public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("LightStep-Access-Token", ASCII_STRING_MARSHALLER);
+
+    private String authToken;
+
+    public GrpcClientInterceptor(String authToken) {
+        this.authToken = authToken;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> methodDescriptor,
+            CallOptions callOptions,
+            Channel channel
+    ) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                channel.newCall(methodDescriptor, callOptions)
+        ) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers){
+                headers.put(ACCESS_TOKEN_HEADER, authToken);
+                super.start(responseListener, headers);
+            }
+        };
+    }
+}

--- a/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
@@ -1,7 +1,15 @@
 package com.lightstep.tracer.grpc;
 
-import io.grpc.*;
-import static io.grpc.Metadata.*;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 
 public class GrpcClientInterceptor implements ClientInterceptor {
     public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("Lightstep-Access-Token", ASCII_STRING_MARSHALLER);

--- a/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
+++ b/grpc/src/main/java/com/lightstep/tracer/grpc/GrpcClientInterceptor.java
@@ -4,7 +4,7 @@ import io.grpc.*;
 import static io.grpc.Metadata.*;
 
 public class GrpcClientInterceptor implements ClientInterceptor {
-    public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("LightStep-Access-Token", ASCII_STRING_MARSHALLER);
+    public static final Key<String> ACCESS_TOKEN_HEADER = Key.of("Lightstep-Access-Token", ASCII_STRING_MARSHALLER);
 
     private String authToken;
 

--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClient.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClient.java
@@ -1,6 +1,9 @@
 package com.lightstep.tracer.shared;
 
-import com.lightstep.tracer.grpc.*;
+import com.lightstep.tracer.grpc.ReportResponse;
+import com.lightstep.tracer.grpc.ReportRequest;
+import com.lightstep.tracer.grpc.GrpcClientInterceptor;
+import com.lightstep.tracer.grpc.CollectorServiceGrpc;
 import com.lightstep.tracer.grpc.CollectorServiceGrpc.CollectorServiceBlockingStub;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;

--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClient.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClient.java
@@ -1,16 +1,11 @@
 package com.lightstep.tracer.shared;
 
-import com.google.protobuf.ByteString;
-import com.lightstep.tracer.grpc.CollectorServiceGrpc;
+import com.lightstep.tracer.grpc.*;
 import com.lightstep.tracer.grpc.CollectorServiceGrpc.CollectorServiceBlockingStub;
-import com.lightstep.tracer.grpc.ReportRequest;
-import com.lightstep.tracer.grpc.ReportResponse;
-import com.lightstep.tracer.grpc.Span;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 class GrpcCollectorClient extends CollectorClient {
@@ -50,6 +45,7 @@ class GrpcCollectorClient extends CollectorClient {
     try {
       ReportResponse response = blockingStub.
               withDeadlineAfter(deadlineMillis, TimeUnit.MILLISECONDS).
+              withInterceptors(new GrpcClientInterceptor(request.getAuth().getAccessToken())).
               report(request);
 
       return response;

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.16.2</version>
+        <version>0.16.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -35,6 +35,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0-M1</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -34,10 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.17.1</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
+++ b/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
@@ -61,7 +61,7 @@ class HttpCollectorClient extends CollectorClient {
         return new Request.Builder()
                 .url(this.collectorURL)
                 .post(RequestBody.create(protoMediaType, request.toByteArray()))
-                .addHeader("LightStep-Access-Token", request.getAuth().getAccessToken())
+                .addHeader("Lightstep-Access-Token", request.getAuth().getAccessToken())
                 .build();
     }
 

--- a/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
+++ b/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
@@ -61,6 +61,7 @@ class HttpCollectorClient extends CollectorClient {
         return new Request.Builder()
                 .url(this.collectorURL)
                 .post(RequestBody.create(protoMediaType, request.toByteArray()))
+                .addHeader("LightStep-Access-Token", request.getAuth().getAccessToken())
                 .build();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>java</artifactId>
     <packaging>pom</packaging>
-    <version>0.17.1</version>
+    <version>0.17.0</version>
 
     <name>LightStep Tracer Java Common (parent)</name>
     <description>LightStep Tracer Java Common (parent)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>java</artifactId>
     <packaging>pom</packaging>
-    <version>0.16.2</version>
+    <version>0.16.3</version>
 
     <name>LightStep Tracer Java Common (parent)</name>
     <description>LightStep Tracer Java Common (parent)</description>


### PR DESCRIPTION
Pull Request to add Lightstep-Access-Token to GRPC and HTTP Tracing Requests.

For the GRPC metadata it adds a client interceptor which appends the metadata before the rpc report call is made.

Finally this updates the javadoc version so tests and installs work properly without failing.