### PR TITLE
Implement custom OkHttp DNS resolution support.

### DIFF
--- a/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClientProvider.java
+++ b/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClientProvider.java
@@ -26,7 +26,8 @@ public class HttpCollectorClientProvider extends CollectorClientProvider {
         return new HttpCollectorClient(
                 tracer,
                 options.collectorUrl,
-                options.deadlineMillis
+                options.deadlineMillis,
+                options.okhttpDns
         );
     }
 }


### PR DESCRIPTION
Fixes #94 

As we can't add a dependency to `OkHttp` to the base package directly, the user will have to pass a custom class that has the same signature as `okhttp.Dns`:

```java
class CustomDns implements Options.OkHttpDns {
  @Override
  public List<InetAddress> lookup(String hostname) {
    ...
  }
}
...

new Options.Builder().withOkHttpDns(new CustomDns()).build();
```

Decided to keep the `OkHttpDns` prefix as this only affects the `OkHttp` transport ;)

Let me know - specially in case it feel somewhat weird.