### PR TITLE
Fix round-robin usage with new GRPC version

### DIFF
--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>tracer-grpc</artifactId>
 
     <properties>
-        <io.grpc.version>1.11.0</io.grpc.version>
-        <io.netty.version>2.0.8.Final</io.netty.version>
+        <io.grpc.version>1.23.0</io.grpc.version>
+        <io.netty.version>2.0.25.Final</io.netty.version>
     </properties>
 
     <build>

--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
@@ -2,7 +2,7 @@ package com.lightstep.tracer.shared;
 
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
-import io.grpc.util.RoundRobinLoadBalancerFactory;
+//import io.grpc.util.RoundRobinLoadBalancerFactory;
 
 // public for reflective instantiation.
 public class GrpcCollectorClientProvider extends CollectorClientProvider {
@@ -38,9 +38,9 @@ public class GrpcCollectorClientProvider extends CollectorClientProvider {
                 );
             }
 
-            if (options.grpcRoundRobin) {
-                builder.loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance());
-            }
+//            if (options.grpcRoundRobin) {
+//                builder.loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance());
+//            }
 
             if (options.collectorUrl.getProtocol().equals("http")) {
                 builder.usePlaintext(true);

--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
@@ -38,9 +38,9 @@ public class GrpcCollectorClientProvider extends CollectorClientProvider {
                 );
             }
 
-//            if (options.grpcRoundRobin) {
-//                builder.loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance());
-//            }
+            if (options.grpcRoundRobin) {
+                builder.defaultLoadBalancingPolicy("round_robin");
+            }
 
             if (options.collectorUrl.getProtocol().equals("http")) {
                 builder.usePlaintext(true);


### PR DESCRIPTION
Lighstep tracer doesn't work with new GRPC version (#103) as RoundRobinLoadBalancerFactory was deprecated and removed.

GRPC and Netty version updated. Code changed to start using GRCP load-balancing round-robin policy.