### PR TITLE
update protobuf version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <io.opentracing.version>0.33.0</io.opentracing.version>
-        <com.google.protobuf.version>3.5.1</com.google.protobuf.version>
+        <com.google.protobuf.version>3.10.0</com.google.protobuf.version>
         <com.google.api.version>1.12.0</com.google.api.version>
     </properties>
 


### PR DESCRIPTION
the current version generates this warning:
```
[error] WARNING: An illegal reflective access operation has occurred
[error] WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/.../protobuf-java-3.5.1.jar) to field java.nio.Buffer.address
[error] WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
[error] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[error] WARNING: All illegal access operations will be denied in a future release
```