### PR TITLE
Close the Tracer for our grpc tests.

### DIFF
--- a/grpc/src/test/java/com/lightstep/tracer/shared/StubTracer.java
+++ b/grpc/src/test/java/com/lightstep/tracer/shared/StubTracer.java
@@ -10,6 +10,8 @@ class StubTracer extends AbstractTracer {
     private final List<LogCall> consoleLogCalls;
     SimpleFuture<Boolean> flushResult = null;
 
+    private static final SimpleFuture<Boolean> SUCCESS_FUTURE = new SimpleFuture(true);
+
     StubTracer(Options options) {
         super(options);
         consoleLogCalls = new ArrayList<>();
@@ -17,6 +19,10 @@ class StubTracer extends AbstractTracer {
 
     @Override
     protected SimpleFuture<Boolean> flushInternal(boolean explicitRequest) {
+        if (flushResult == null) {
+            return SUCCESS_FUTURE;
+        }
+
         return flushResult;
     }
 


### PR DESCRIPTION
It seems the new version is more strict/verbose
upon resources being released, so actually close the
grpc channels in our tests.