### PR TITLE
Bump okhttp from 3.10.0 to 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <a name="Pending Release"></a>
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-java-common/compare/0.19.2...master)
+* Bump okhttp from 3.10.0 to 4.3.1
 
 <a name="0.19.2"></a>
 ## [0.19.2](https://github.com/lightstep/lightstep-tracer-java-common/compare/0.19.1...0.19.2)

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>tracer-okhttp</artifactId>
 
     <properties>
-        <com.squareup.okhttp3.version>3.10.0</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>4.3.1</com.squareup.okhttp3.version>
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 


### PR DESCRIPTION
This is to avoid being hit by https://github.com/square/okhttp/issues/3957.