### PR TITLE
chore: change signature of ManagedChannelBuilder.usePlaintext

### DIFF
--- a/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
+++ b/grpc/src/main/java/com/lightstep/tracer/shared/GrpcCollectorClientProvider.java
@@ -48,7 +48,7 @@ public class GrpcCollectorClientProvider extends CollectorClientProvider {
             }
 
             if (options.collectorUrl.getProtocol().equals("http")) {
-                builder.usePlaintext(true);
+                builder.usePlaintext();
             }
             return new GrpcCollectorClient(
                     tracer,


### PR DESCRIPTION
ManagedChannelBuilder.usePlaintext(boolean) has been deprecated since [v1.11.0](https://github.com/grpc/grpc-java/releases/tag/v1.11.0)
and was removed in [v1.26.0](https://github.com/grpc/grpc-java/releases/tag/v1.26.0).