### PR TITLE
use Throwable in printLogToConsole to allow proper exception logging

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -591,7 +591,7 @@ public abstract class AbstractTracer implements Tracer {
         if (!response.getErrorsList().isEmpty()) {
             List<String> errs = response.getErrorsList();
             for (String err : errs) {
-                this.error("Collector response contained error: ", err);
+                this.error("Collector response contained error: " + err);
             }
             return ReportResult.Error(spans.size());
         }
@@ -677,11 +677,11 @@ public abstract class AbstractTracer implements Tracer {
      * Internal logging.
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    protected void debug(String msg, Object payload) {
+    protected void debug(String msg, Throwable throwable) {
         if (verbosity < VERBOSITY_DEBUG) {
             return;
         }
-        printLogToConsole(DEBUG, msg, payload);
+        printLogToConsole(DEBUG, msg, throwable);
     }
 
     /**
@@ -696,11 +696,11 @@ public abstract class AbstractTracer implements Tracer {
      * Internal logging.
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    protected void info(String msg, Object payload) {
+    protected void info(String msg, Throwable throwable) {
         if (verbosity < VERBOSITY_INFO) {
             return;
         }
-        printLogToConsole(InternalLogLevel.INFO, msg, payload);
+        printLogToConsole(InternalLogLevel.INFO, msg, throwable);
     }
 
     /**
@@ -715,11 +715,11 @@ public abstract class AbstractTracer implements Tracer {
      * Internal warning.
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    protected void warn(String msg, Object payload) {
+    protected void warn(String msg, Throwable throwable) {
         if (verbosity < VERBOSITY_INFO) {
             return;
         }
-        printLogToConsole(InternalLogLevel.WARN, msg, payload);
+        printLogToConsole(InternalLogLevel.WARN, msg, throwable);
     }
 
     /**
@@ -734,7 +734,7 @@ public abstract class AbstractTracer implements Tracer {
      * Internal error.
      */
     @SuppressWarnings("WeakerAccess")
-    protected void error(String msg, Object payload) {
+    protected void error(String msg, Throwable throwable) {
         if (verbosity < VERBOSITY_FIRST_ERROR_ONLY) {
             return;
         }
@@ -742,10 +742,10 @@ public abstract class AbstractTracer implements Tracer {
             return;
         }
         firstErrorLogged = true;
-        printLogToConsole(ERROR, msg, payload);
+        printLogToConsole(ERROR, msg, throwable);
     }
 
-    protected abstract void printLogToConsole(InternalLogLevel level, String msg, Object payload);
+    protected abstract void printLogToConsole(InternalLogLevel level, String msg, Throwable throwable);
 
 
     String generateTraceURL(long spanId) {

--- a/example/src/main/java/com/lightstep/tracer/shared/ExampleTracer.java
+++ b/example/src/main/java/com/lightstep/tracer/shared/ExampleTracer.java
@@ -1,10 +1,5 @@
 package com.lightstep.tracer.shared;
 
-import com.lightstep.tracer.shared.AbstractTracer;
-import com.lightstep.tracer.shared.Options;
-import com.lightstep.tracer.shared.SimpleFuture;
-import io.opentracing.Span;
-
 public class ExampleTracer extends AbstractTracer {
     public ExampleTracer(Options options) {
         super(options);
@@ -17,11 +12,10 @@ public class ExampleTracer extends AbstractTracer {
     }
 
     @Override
-    protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {
-        String s = msg;
-        if (payload != null) {
-            s += " " + payload.toString();
+    protected void printLogToConsole(InternalLogLevel level, String msg, Throwable throwable) {
+        System.out.println(msg);
+        if (throwable != null) {
+            throwable.printStackTrace();
         }
-        System.out.println(s);
     }
 }

--- a/grpc/src/test/java/com/lightstep/tracer/shared/StubTracer.java
+++ b/grpc/src/test/java/com/lightstep/tracer/shared/StubTracer.java
@@ -10,7 +10,7 @@ class StubTracer extends AbstractTracer {
     private final List<LogCall> consoleLogCalls;
     SimpleFuture<Boolean> flushResult = null;
 
-    private static final SimpleFuture<Boolean> SUCCESS_FUTURE = new SimpleFuture(true);
+    private static final SimpleFuture<Boolean> SUCCESS_FUTURE = new SimpleFuture<>(true);
 
     StubTracer(Options options) {
         super(options);
@@ -27,10 +27,10 @@ class StubTracer extends AbstractTracer {
     }
 
     @Override
-    protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {
+    protected void printLogToConsole(InternalLogLevel level, String msg, Throwable throwable) {
         // this can only be null when print is called during Tracer construction
         if (consoleLogCalls != null) {
-            consoleLogCalls.add(new LogCall(level, msg, payload));
+            consoleLogCalls.add(new LogCall(level, msg, throwable));
         }
     }
 
@@ -45,15 +45,15 @@ class StubTracer extends AbstractTracer {
         return consoleLogCalls.size();
     }
 
-    class LogCall {
+    static class LogCall {
         final InternalLogLevel level;
         final String msg;
-        final Object payload;
+        final Throwable throwable;
 
-        private LogCall(InternalLogLevel level, String msg, Object payload)  {
+        private LogCall(InternalLogLevel level, String msg, Throwable throwable)  {
             this.level = level;
             this.msg = msg;
-            this.payload = payload;
+            this.throwable = throwable;
         }
     }
 }


### PR DESCRIPTION
comes from https://github.com/lightstep/lightstep-tracer-java-common/issues/144