### PR TITLE
Fix race condition with creating lightstep-reporting-thread

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/ClockState.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClockState.java
@@ -154,9 +154,7 @@ class ClockState {
      * in the current offset.
      */
     boolean isReady() {
-        synchronized (mutex) {
-            return samples.size() > 3;
-        }
+        return activeSampleCount() > 3;
     }
 
     int activeSampleCount() {


### PR DESCRIPTION
Due to lack of synchronization it's possible to spawn multiple
threads and forget the reference to everyone except one.

This means that the forgotten threads will never be interrupted and
keep running forever