### PR TITLE
Makes SpanContext#withBaggageItem Publicly Accessible

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -89,7 +89,8 @@ public class SpanContext implements io.opentracing.SpanContext {
         return baggage;
     }
 
-    SpanContext withBaggageItem(String key, String value) {
+    @SuppressWarnings("WeakerAccess")
+    public SpanContext withBaggageItem(String key, String value) {
         // This is really a "set" not a "with" but keeping as is to preserve behavior.
         this.baggage.put(key, value);
         return new SpanContext(this.getTraceId(), this.getSpanId(), this.baggage, this.foreignTraceId);


### PR DESCRIPTION
Make `SpanContext#withBaggageItem` publicly accessible to allow 3rd party propagators to set baggage items upon extraction.

Intended to fix #162 