### PR TITLE
Make SpanContext truly immutable.

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -90,9 +90,10 @@ public class SpanContext implements io.opentracing.SpanContext {
     }
 
     SpanContext withBaggageItem(String key, String value) {
-        // This is really a "set" not a "with" but keeping as is to preserve behavior.
-        this.baggage.put(key, value);
-        return new SpanContext(this.getTraceId(), this.getSpanId(), this.baggage, this.foreignTraceId);
+        // Do NOT modify our own baggage, as SpanContext is expected to be immutable.
+        Map<String, String> newBaggage = new HashMap<String, String>(this.baggage);
+        newBaggage.put(key, value);
+        return new SpanContext(this.getTraceId(), this.getSpanId(), newBaggage, this.foreignTraceId);
     }
 
     @Override

--- a/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
@@ -53,9 +53,9 @@ public class SpanTest {
     public void testContext_isImmutable() {
       undertest.setBaggageItem("foo", "bar");
       SpanContext anotherSpanContext = undertest.context();
-      assertNotEquals(spanContext, anotherSpanContext);
       assertNull(spanContext.getBaggageItem("foo"));
       assertNotNull(anotherSpanContext.getBaggageItem("foo"));
+      assertNotNull(undertest.getBaggageItem("foo"));
     }
 
     @Test

--- a/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/SpanTest.java
@@ -50,6 +50,15 @@ public class SpanTest {
     }
 
     @Test
+    public void testContext_isImmutable() {
+      undertest.setBaggageItem("foo", "bar");
+      SpanContext anotherSpanContext = undertest.context();
+      assertNotEquals(spanContext, anotherSpanContext);
+      assertNull(spanContext.getBaggageItem("foo"));
+      assertNotNull(anotherSpanContext.getBaggageItem("foo"));
+    }
+
+    @Test
     public void testContext() {
         assertSame(spanContext, undertest.context());
     }


### PR DESCRIPTION
Required to properly address #163 

Also, this is part of the OpenTracing specification requirements.