### PR TITLE
Use shaded okhttp 3.10.0 in our transport artifact.

### DIFF
--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -43,6 +43,42 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.squareup.okhttp3:okhttp</include>
+                                    <include>com.squareup.okio:okio</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>lightstep.okhttp3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>lightstep.okio</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <io.grpc.version>1.23.0</io.grpc.version>
         <io.netty.version>2.0.25.Final</io.netty.version>
 
-        <com.squareup.okhttp3.version>4.3.1</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.10.0</com.squareup.okhttp3.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Now we will keep the okhttp engine private. We try to do this to allow users to use newer versions of okhttp, while staying Android 7/23 compatible.