### PR TITLE
Restore 4.x version for Okhttp.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <io.grpc.version>1.23.0</io.grpc.version>
         <io.netty.version>2.0.25.Final</io.netty.version>
 
-        <com.squareup.okhttp3.version>3.10.0</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>4.3.1</com.squareup.okhttp3.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
I had originally used 3.x which is compatible
with Android, but it has a resource leaking
problem, hence we go back to 4.x for now.