### PR TITLE
Implement retry attempt logic

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -131,6 +131,7 @@ public abstract class AbstractTracer implements Tracer {
     boolean firstReportHasRun;
     boolean disableMetaEventLogging;
     boolean metaEventLoggingEnabled;
+    boolean dropSpansOnFailure;
 
     public AbstractTracer(Options options) {
         scopeManager = options.scopeManager;
@@ -209,6 +210,8 @@ public abstract class AbstractTracer implements Tracer {
         firstReportHasRun = false;
         metaEventLoggingEnabled = false;
         disableMetaEventLogging = options.disableMetaEventLogging;
+
+        dropSpansOnFailure = options.dropSpansOnFailure;
     }
 
     /**
@@ -609,7 +612,7 @@ public abstract class AbstractTracer implements Tracer {
             }
           }
 
-          if (reportedSpans.size() == 0) {
+          if (dropSpansOnFailure || reportedSpans.size() == 0) {
             return ReportResult.Error(reportedSpans.size());
           }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -656,25 +656,27 @@ public abstract class AbstractTracer implements Tracer {
         return ReportResult.Success();
     }
 
-    static int mergeSpans(ArrayList<Span> targetList, ArrayList<Span> fromList, int maxSpanCount) {
+    /**
+     * Merges spans `fromList` into `targetList`, filling `targetList` up to `maxSpanCount`.
+     *
+     * @param targetList the list where spans will be merged to.
+     * @param fromList the list where spans will be merged from.
+     * @param maxSpanCount maximum count `targetList` will have after this operation.
+     *
+     * Returns the count of actual spans that were merged into `targetList`.
+     */
+    int mergeSpans(ArrayList<Span> targetList, ArrayList<Span> fromList, int maxSpanCount) {
         int available = maxSpanCount - targetList.size();
         if (available <= 0) {
-          System.out.println("-- mergeSpans: not available --");
-          System.out.println(" maxBufferedSpans = " + maxSpanCount);
-          System.out.println(" current buffer size = " + targetList.size());
-          System.out.println(" to-restore buffer size = " + fromList.size());
-          System.out.println("----");
+          warn("Buffer is full, dropping " + fromList.size() + " spans.");
           return 0;
         }
 
+        /* Note: Somewhat arbitrarily dropping the spans that won't
+         * fit; could be more principled here to avoid bias. */
         int restoredCount = Math.min(available, fromList.size());
-        System.out.println("-- mergeSpans: restoring --");
-        System.out.println(" maxBufferedSpans = " + maxSpanCount);
-        System.out.println(" current buffer size = " + targetList.size());
-        System.out.println(" to-restore buffer size = " + fromList.size());
-        System.out.println(" restored count = " + restoredCount);
         targetList.addAll(fromList.subList(0, restoredCount));
-        System.out.println(" current buffer size (updated) = " + targetList.size());
+        warn("About to restore " + restoredCount + " spans out of " + fromList.size() + " from a failed report");
         return restoredCount;
     }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -4,13 +4,13 @@ import com.lightstep.tracer.grpc.InternalMetrics;
 import com.lightstep.tracer.grpc.MetricsSample;
 
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tracks client metrics for internal purposes.
  */
 class ClientMetrics {
-    private final AtomicLong spansDropped = new AtomicLong(0);
+    private final AtomicInteger spansDropped = new AtomicInteger(0);
 
     void addSpansDropped(int size) {
         if (size != 0) {
@@ -18,7 +18,7 @@ class ClientMetrics {
         }
     }
 
-    long getSpansDropped() {
+    int getSpansDropped() {
         return spansDropped.get();
     }
 
@@ -31,7 +31,7 @@ class ClientMetrics {
                 ).build();
     }
 
-    private long getAndResetSpansDropped() {
+    private int getAndResetSpansDropped() {
         return spansDropped.getAndSet(0);
     }
 }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -140,6 +140,8 @@ public final class Options {
      */
     final long deadlineMillis;
 
+    final boolean dropSpansOnFailure;
+
     private Options(
             String accessToken,
             String serviceVersion,
@@ -161,7 +163,8 @@ public final class Options {
             String grpcCollectorTarget,
             boolean grpcRoundRobin,
             OkHttpDns okhttpDns,
-            boolean disableMetaEventLogging
+            boolean disableMetaEventLogging,
+            boolean dropSpansOnFailure
     ) {
         this.accessToken = accessToken;
         this.serviceVersion = serviceVersion;
@@ -184,6 +187,7 @@ public final class Options {
         this.grpcRoundRobin = grpcRoundRobin;
         this.okhttpDns = okhttpDns;
         this.disableMetaEventLogging = disableMetaEventLogging;
+        this.dropSpansOnFailure = dropSpansOnFailure;
     }
 
     long getGuid() {
@@ -219,6 +223,7 @@ public final class Options {
         private String grpcCollectorTarget;
         private boolean grpcRoundRobin = false;
         private OkHttpDns okhttpDns;
+        private boolean dropSpansOnFailure = true;
 
         public OptionsBuilder() {
         }
@@ -247,6 +252,7 @@ public final class Options {
             this.grpcCollectorTarget = options.grpcCollectorTarget;
             this.grpcRoundRobin = options.grpcRoundRobin;
             this.okhttpDns = options.okhttpDns;
+            this.dropSpansOnFailure = options.dropSpansOnFailure;
         }
 
         private static boolean getEnvMetricsDisabled() {
@@ -255,6 +261,19 @@ public final class Options {
                 return "false".equals(metricEnabled);
             }
             return LightStepConstants.Metrics.DEFAULT_DISABLE_METRICS;
+        }
+
+        /**
+         * Instructs the Tracer to either to drop Spans for failed requests
+         * or else do a best effort to keep them in the current buffer.
+         *
+         * Defaults to true.
+         *
+         * @param dropSpansOnFailure whether the tracer should drop spans for failed requests.
+         */
+        public OptionsBuilder withDropSpansOnFailure(boolean dropSpansOnFailure) {
+          this.dropSpansOnFailure = dropSpansOnFailure;
+          return this;
         }
 
         /**
@@ -606,7 +625,8 @@ public final class Options {
                     grpcCollectorTarget,
                     grpcRoundRobin,
                     okhttpDns,
-                    disableMetaEventLogging
+                    disableMetaEventLogging,
+                    dropSpansOnFailure
             );
         }
 

--- a/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
+++ b/okhttp/src/main/java/com/lightstep/tracer/shared/HttpCollectorClient.java
@@ -77,8 +77,8 @@ class HttpCollectorClient extends CollectorClient {
         try {
             if (!response.isSuccessful()) {
                 this.tracer.error(String.format(
-                        "Collector returned non-successful http code %d",
-                        response.code()
+                        "Collector returned non-successful http code %d, message: %s",
+                        response.code(), response.message()
                 ));
                 return null;
             }


### PR DESCRIPTION
The Java tracer, unlike the Go or Python tracers, drops Spans upon failed report requests. This PR addresses this in the follow fashion:

* The selection and logic is essentially the same as the Go tracer, which does a best-effort to keep Spans from a previous report, depending on the max buffer size.
* The minimum poll period was changed to 500ms (from 40ms), in order to prevent busy CPU cycles even in the presence of exponential retry logic. 500ms is also used by the Go tracer.
* By default we keep the legacy behavior of dropping Spans upon failure - done to potentially break existing users. Otherwise, to enable this, `withDropSpansOnFailure(false)` has to be set.
* Otherwise, include the error message when the http transport fails, as status code is barely useful.